### PR TITLE
Fix dragging while mouse over the preview image

### DIFF
--- a/src/atoms/SvgPreview.tsx
+++ b/src/atoms/SvgPreview.tsx
@@ -33,6 +33,7 @@ const SvgPreview = ({svg, width, height}: Props): JSX.Element => (
             height={height || '100%'}
             src={`data:image/svg+xml;utf8,${encodeURIComponent(svg)}`}
             alt={'Ergogen SVG Output preview'}
+            draggable="false"
         />
     </StyledPanZoom>
 );


### PR DESCRIPTION
By adding this simple draggable="false", images can be clicked and dragged without any issues. Otherwise, click and drag is a nuisance and makes simply quickly panning very annoying.

Tested locally with success.