### PR TITLE
feat: Add generate and download buttons for mobile

### DIFF
--- a/src/Ergogen.tsx
+++ b/src/Ergogen.tsx
@@ -502,9 +502,14 @@ const Ergogen = () => {
               <OutlineIconButton className={!configContext.showConfig ? 'active' : ''} onClick={() => configContext.setShowConfig(false)}>Outputs</OutlineIconButton>
               <Spacer />
               {configContext.showConfig && (
-                <GenerateIconButton onClick={() => configContext.generateNow(configContext.configInput, configContext.injectionInput, { pointsonly: false })}>
-                  <span className="material-symbols-outlined">refresh</span>
-                </GenerateIconButton>
+                <>
+                  <GenerateIconButton onClick={() => configContext.generateNow(configContext.configInput, configContext.injectionInput, { pointsonly: false })}>
+                    <span className="material-symbols-outlined">refresh</span>
+                  </GenerateIconButton>
+                  <OutlineIconButton onClick={handleDownload}>
+                    <span className="material-symbols-outlined">download</span>
+                  </OutlineIconButton>
+                </>
               )}
               {!configContext.showConfig && (
                 <OutlineIconButton onClick={() => configContext.setShowDownloads(!configContext.showDownloads)}>

--- a/src/Ergogen.tsx
+++ b/src/Ergogen.tsx
@@ -105,6 +105,33 @@ const OutlineIconButton = styled.button`
 `;
 
 /**
+ * A styled button with a green background, used for primary actions on mobile.
+ */
+const GenerateIconButton = styled.button`
+    background-color: #239923;
+    transition: background-color .15s ease-in-out;
+    border: none;
+    border-radius: 6px;
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    cursor: pointer;
+    height: 34px;
+    width: 34px;
+    font-family: 'Roboto', sans-serif;
+
+    .material-symbols-outlined {
+        font-size: 16px !important;
+    }
+
+    &:hover {
+        background-color: #1e8e1e;
+    }
+`;
+
+/**
  * A container for editor components, ensuring it fills available space.
  */
 const EditorContainer = styled.div`
@@ -474,6 +501,11 @@ const Ergogen = () => {
               <OutlineIconButton className={configContext.showConfig ? 'active' : ''} onClick={() => configContext.setShowConfig(true)}>Config</OutlineIconButton>
               <OutlineIconButton className={!configContext.showConfig ? 'active' : ''} onClick={() => configContext.setShowConfig(false)}>Outputs</OutlineIconButton>
               <Spacer />
+              {configContext.showConfig && (
+                <GenerateIconButton onClick={() => configContext.generateNow(configContext.configInput, configContext.injectionInput, { pointsonly: false })}>
+                  <span className="material-symbols-outlined">refresh</span>
+                </GenerateIconButton>
+              )}
               {!configContext.showConfig && (
                 <OutlineIconButton onClick={() => configContext.setShowDownloads(!configContext.showDownloads)}>
                   <span className="material-symbols-outlined">

--- a/src/Ergogen.tsx
+++ b/src/Ergogen.tsx
@@ -55,7 +55,7 @@ const SubHeaderContainer = styled.div`
       align-items: center;
       border-bottom: 1px solid #3f3f3f;
       flex-direction: row;
-      gap: 16px;
+      gap: 10px;
       padding: 0 1rem;
       flex-shrink: 0;
 

--- a/src/atoms/Header.tsx
+++ b/src/atoms/Header.tsx
@@ -24,7 +24,7 @@ const HeaderContainer = styled.header`
 const LeftContainer = styled.div`
     display: flex;
     align-items: center;
-    gap: 16px;
+    gap: 10px;
     flex-direction: row;
     flex-grow: 1;
     min-width: 0;


### PR DESCRIPTION
This PR adds 'Generate' and 'Download' buttons to the sub-header, which is visible on mobile devices. This improves the user experience on smaller screens where the main buttons and keyboard shortcuts are not available.