### PR TITLE
Align layout editor with ergogen structures

### DIFF
--- a/src/layout-editor/LayoutEditor.tsx
+++ b/src/layout-editor/LayoutEditor.tsx
@@ -562,7 +562,12 @@ const SettingsPanel: React.FC = () => {
           <SettingsInput
             type="text"
             value={layout.meta.name || ''}
-            onChange={(e) => dispatch({ type: 'UPDATE_META', payload: { name: e.target.value } })}
+            onChange={(e) =>
+              dispatch({
+                type: 'UPDATE_META',
+                payload: { name: e.target.value },
+              })
+            }
             placeholder="Keyboard Name"
             style={{ width: '120px', textAlign: 'left' }}
           />
@@ -572,7 +577,12 @@ const SettingsPanel: React.FC = () => {
           <SettingsInput
             type="text"
             value={layout.meta.version || ''}
-            onChange={(e) => dispatch({ type: 'UPDATE_META', payload: { version: e.target.value } })}
+            onChange={(e) =>
+              dispatch({
+                type: 'UPDATE_META',
+                payload: { version: e.target.value },
+              })
+            }
             placeholder="0.1"
             style={{ width: '60px' }}
           />
@@ -582,7 +592,12 @@ const SettingsPanel: React.FC = () => {
           <SettingsInput
             type="text"
             value={layout.meta.author || ''}
-            onChange={(e) => dispatch({ type: 'UPDATE_META', payload: { author: e.target.value } })}
+            onChange={(e) =>
+              dispatch({
+                type: 'UPDATE_META',
+                payload: { author: e.target.value },
+              })
+            }
             placeholder="Your Name"
             style={{ width: '120px', textAlign: 'left' }}
           />

--- a/src/layout-editor/LayoutEditorContext.tsx
+++ b/src/layout-editor/LayoutEditorContext.tsx
@@ -130,7 +130,11 @@ function cloneLayout(layout: EditorLayout): EditorLayout {
     keys: new Map(
       Array.from(layout.keys.entries()).map(([k, v]) => [
         k,
-        { ...v, ergogenProps: { ...v.ergogenProps } },
+        {
+          ...v,
+          rotationOrigin: [...v.rotationOrigin] as [number, number],
+          meta: { ...v.meta },
+        },
       ])
     ),
     zones: new Map(
@@ -138,18 +142,24 @@ function cloneLayout(layout: EditorLayout): EditorLayout {
         k,
         {
           ...v,
-          anchor: { ...v.anchor },
+          anchor: {
+            ...v.anchor,
+            shift: [...v.anchor.shift] as [number, number],
+          },
+          key: { ...v.key },
           columns: v.columns.map((c) => ({
             ...c,
-            splayOrigin: [...c.splayOrigin] as [number, number],
-            ergogenProps: { ...c.ergogenProps },
+            key: {
+              ...c.key,
+              origin: [...c.key.origin] as [number, number],
+            },
+            rows: { ...c.rows },
           })),
           rows: v.rows.map((r) => ({
             ...r,
-            ergogenProps: { ...r.ergogenProps },
+            key: { ...r.key },
           })),
-          keys: [...v.keys],
-          ergogenProps: { ...v.ergogenProps },
+          mirror: v.mirror ? { ...v.mirror } : undefined,
         },
       ])
     ),
@@ -546,10 +556,11 @@ function editorReducer(state: EditorState, action: EditorAction): EditorState {
 
     case 'UPDATE_META': {
       const newMeta = { ...state.layout.meta, ...action.payload };
-      
+
       // Validate engine version if it's being updated
       if (action.payload.engine) {
-        const semverRegex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+        const semverRegex =
+          /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
         if (!semverRegex.test(action.payload.engine)) {
           // Ignore invalid engine version
           return state;
@@ -732,14 +743,16 @@ export function LayoutEditorProvider({ children }: { children: ReactNode }) {
           columns: [
             {
               name: 'col1',
-              spread: 19.05,
-              stagger: 0,
-              splay: 0,
-              splayOrigin: [0, 0],
-              ergogenProps: {},
+              key: {
+                spread: KEY_UNIT_MM,
+                stagger: 0,
+                splay: 0,
+                origin: [0, 0],
+              },
+              rows: {},
             },
           ],
-          rows: [{ name: 'row1', ergogenProps: {} }],
+          rows: [{ name: 'row1', key: {} }],
         },
       });
     }
@@ -850,14 +863,16 @@ export function LayoutEditorProvider({ children }: { children: ReactNode }) {
             columns: [
               {
                 name: 'col1',
-                spread: 19.05,
-                stagger: 0,
-                splay: 0,
-                splayOrigin: [0, 0],
-                ergogenProps: {},
+                key: {
+                  spread: KEY_UNIT_MM,
+                  stagger: 0,
+                  splay: 0,
+                  origin: [0, 0],
+                },
+                rows: {},
               },
             ],
-            rows: [{ name: 'row1', ergogenProps: {} }],
+            rows: [{ name: 'row1', key: {} }],
           },
         });
       }

--- a/src/layout-editor/components/AddKeyOverlay.test.tsx
+++ b/src/layout-editor/components/AddKeyOverlay.test.tsx
@@ -40,24 +40,28 @@ describe('AddKeyOverlay', () => {
     columns: [
       {
         name: 'col1',
-        spread: 19.05,
-        stagger: 0,
-        splay: 0,
-        splayOrigin: [0, 0],
-        ergogenProps: {},
+        key: {
+          spread: 19.05,
+          stagger: 0,
+          splay: 0,
+          origin: [0, 0],
+        },
+        rows: {},
       },
       {
         name: 'col2',
-        spread: 19.05,
-        stagger: 0,
-        splay: 0,
-        splayOrigin: [0, 0],
-        ergogenProps: {},
+        key: {
+          spread: 19.05,
+          stagger: 0,
+          splay: 0,
+          origin: [0, 0],
+        },
+        rows: {},
       },
     ],
     rows: [
-      { name: 'row1', ergogenProps: {} },
-      { name: 'row2', ergogenProps: {} },
+      { name: 'row1', key: {} },
+      { name: 'row2', key: {} },
     ],
     ...overrides,
   });

--- a/src/layout-editor/components/EditorToolbar.tsx
+++ b/src/layout-editor/components/EditorToolbar.tsx
@@ -167,11 +167,7 @@ export const EditorToolbar: React.FC = () => {
 
       <ToolSection>
         <SectionLabel>View</SectionLabel>
-        <ToolbarItem
-          icon="zoom_in"
-          title="Zoom In"
-          onClick={() => zoom(0.1)}
-        />
+        <ToolbarItem icon="zoom_in" title="Zoom In" onClick={() => zoom(0.1)} />
         <ToolbarItem
           icon="zoom_out"
           title="Zoom Out"

--- a/src/layout-editor/components/KeyPropertiesPanel.tsx
+++ b/src/layout-editor/components/KeyPropertiesPanel.tsx
@@ -74,11 +74,6 @@ const PropertyInputGroup = styled.div`
   flex: 1;
 `;
 
-const SmallInput = styled(PropertyInput)`
-  width: 60px;
-  flex: none;
-`;
-
 const InputWithLabel = styled.div`
   display: flex;
   flex: 1;
@@ -304,7 +299,9 @@ export const KeyPropertiesPanel: React.FC = () => {
               <SmallLabel>Width</SmallLabel>
               <UnitInput
                 value={singleKey!.width}
-                onChange={(val) => handlePropertyChange('width', Math.max(0.25, val))}
+                onChange={(val) =>
+                  handlePropertyChange('width', Math.max(0.25, val))
+                }
                 step={0.25}
                 min={0.25}
               />
@@ -313,7 +310,9 @@ export const KeyPropertiesPanel: React.FC = () => {
               <SmallLabel>Height</SmallLabel>
               <UnitInput
                 value={singleKey!.height}
-                onChange={(val) => handlePropertyChange('height', Math.max(0.25, val))}
+                onChange={(val) =>
+                  handlePropertyChange('height', Math.max(0.25, val))
+                }
                 step={0.25}
                 min={0.25}
               />

--- a/src/layout-editor/components/LayoutCanvas.tsx
+++ b/src/layout-editor/components/LayoutCanvas.tsx
@@ -74,8 +74,6 @@ const StatusItem = styled.span`
   gap: 4px;
 `;
 
-
-
 interface LayoutCanvasProps {
   className?: string;
 }
@@ -951,7 +949,6 @@ export const LayoutCanvas: React.FC<LayoutCanvasProps> = ({ className }) => {
         />
       )}
       <StatusBar>
-
         <StatusItem>Keys: {layout.keys.size}</StatusItem>
         <StatusItem>Selected: {selection.keys.size}</StatusItem>
         <StatusItem>Zoom: {Math.round(zoom * 100)}%</StatusItem>

--- a/src/layout-editor/components/LayoutCanvas.tsx
+++ b/src/layout-editor/components/LayoutCanvas.tsx
@@ -127,10 +127,13 @@ function renderKey(
   }
 
   // Apply rotation around key center
+  // Note: Canvas rotation is clockwise for positive angles, but Ergogen uses
+  // counter-clockwise (standard math convention). Since Y-axis is flipped,
+  // we negate the rotation to get counter-clockwise behavior.
   const totalRotation = key.rotation + globalRotation;
   if (totalRotation !== 0) {
     ctx.translate(centerX, centerY);
-    ctx.rotate((totalRotation * Math.PI) / 180);
+    ctx.rotate((-totalRotation * Math.PI) / 180);
     ctx.translate(-centerX, -centerY);
   }
 
@@ -350,8 +353,10 @@ function isPointInKey(
 
   const totalRotation = key.rotation + globalRotation;
   if (totalRotation !== 0) {
-    // For rotated keys, transform the point to key's local space
-    const angle = (-totalRotation * Math.PI) / 180;
+    // For rotated keys, transform the point to key's local space.
+    // Since we render with -totalRotation (to make positive angles counter-clockwise),
+    // we use +totalRotation here to transform the point back to local space.
+    const angle = (totalRotation * Math.PI) / 180;
     const cos = Math.cos(angle);
     const sin = Math.sin(angle);
     const dx = px - centerX;

--- a/src/layout-editor/components/UnitInput.tsx
+++ b/src/layout-editor/components/UnitInput.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import { theme } from '../../theme/theme';
 
-export type UnitType = 'U' | 'u' | 'mm' | 'deg';
+type UnitType = 'U' | 'u' | 'mm' | 'deg';
 
 interface UnitDefinition {
   value: UnitType;
@@ -17,9 +17,7 @@ const LENGTH_UNITS: UnitDefinition[] = [
   { value: 'mm', label: 'mm', factor: 1 },
 ];
 
-const DEGREE_UNIT: UnitDefinition[] = [
-  { value: 'deg', label: '°', factor: 1 },
-];
+const DEGREE_UNIT: UnitDefinition[] = [{ value: 'deg', label: '°', factor: 1 }];
 
 interface UnitInputProps {
   value: number;
@@ -150,14 +148,11 @@ export const UnitInput: React.FC<UnitInputProps> = ({
   const [inputValue, setInputValue] = useState<string>('');
 
   // Calculate displayed value based on current unit
-  const getDisplayValue = useCallback(
-    (val: number, unit: UnitDefinition) => {
-      const converted = val * unit.factor;
-      // Round to 3 decimal places to avoid floating point errors
-      return Math.round(converted * 1000) / 1000;
-    },
-    []
-  );
+  const getDisplayValue = useCallback((val: number, unit: UnitDefinition) => {
+    const converted = val * unit.factor;
+    // Round to 3 decimal places to avoid floating point errors
+    return Math.round(converted * 1000) / 1000;
+  }, []);
 
   // Update input value when prop value or unit changes
   useEffect(() => {
@@ -188,7 +183,7 @@ export const UnitInput: React.FC<UnitInputProps> = ({
     const currentVal = parseFloat(inputValue) || 0;
     const actualStep = step || (currentUnit.value === 'mm' ? 1 : 0.25);
     const newVal = currentVal + actualStep;
-    
+
     // Check max
     if (max !== undefined && newVal / currentUnit.factor > max) return;
 

--- a/src/layout-editor/components/ZonePropertiesPanel.tsx
+++ b/src/layout-editor/components/ZonePropertiesPanel.tsx
@@ -498,10 +498,10 @@ export const ZonePropertiesPanel: React.FC = () => {
                           style={{ width: '60px' }}
                         />
                         <UnitInput
-                          value={col.stagger}
+                          value={col.key.stagger}
                           onChange={(val) =>
                             handleUpdateColumn(zone.name, i, {
-                              stagger: val,
+                              key: { ...col.key, stagger: val },
                             })
                           }
                           step={0.25}
@@ -509,10 +509,10 @@ export const ZonePropertiesPanel: React.FC = () => {
                         />
                         <UnitInput
                           type="angle"
-                          value={col.splay}
+                          value={col.key.splay}
                           onChange={(val) =>
                             handleUpdateColumn(zone.name, i, {
-                              splay: val,
+                              key: { ...col.key, splay: val },
                             })
                           }
                           step={5}

--- a/src/layout-editor/core/Point.ts
+++ b/src/layout-editor/core/Point.ts
@@ -1,0 +1,279 @@
+/**
+ * Point class - TypeScript implementation of Ergogen's Point class.
+ *
+ * This class represents a positioned point in 2D space with rotation,
+ * matching the behavior and API of Ergogen's src/point.js
+ *
+ * A Point has:
+ * - x, y: position in millimeters
+ * - r: rotation in degrees
+ * - meta: object containing all associated metadata
+ */
+
+/**
+ * Metadata associated with a Point, matching Ergogen's key metadata structure.
+ */
+export interface PointMeta {
+  /** Name of this point (e.g., "matrix_pinky_bottom") */
+  name?: string;
+  /** Zone this point belongs to */
+  zone?: ZoneReference;
+  /** Column this point belongs to */
+  col?: ColumnReference;
+  /** Row name */
+  row?: string;
+  /** Combined column/row identifier */
+  colrow?: string;
+  /** Whether this point is mirrored */
+  mirrored?: boolean;
+  /** Asymmetry setting: 'source', 'clone', or 'both' */
+  asym?: 'source' | 'clone' | 'both';
+  /** Whether to skip this point in output */
+  skip?: boolean;
+
+  // Key-level properties (from Ergogen's key inheritance)
+  /** Vertical offset (stagger) in mm */
+  stagger?: number;
+  /** Horizontal offset (spread) in mm */
+  spread?: number;
+  /** Column rotation (splay) in degrees */
+  splay?: number;
+  /** Origin for splay rotation [x, y] in mm */
+  origin?: [number, number];
+  /** Key-level rotation offset in degrees */
+  orient?: number;
+  /** Key-level shift [x, y] in mm */
+  shift?: [number, number];
+  /** Key-level rotation in degrees */
+  rotate?: number;
+  /** Key width in mm */
+  width?: number;
+  /** Key height in mm */
+  height?: number;
+  /** Padding to next key in mm */
+  padding?: number;
+  /** Autobind distance in mm */
+  autobind?: number;
+  /** Bind values [top, right, bottom, left] in mm */
+  bind?: [number, number, number, number];
+
+  // Additional custom properties
+  [key: string]: unknown;
+}
+
+/**
+ * Reference to a zone configuration.
+ */
+interface ZoneReference {
+  name: string;
+  columns?: Record<string, unknown>;
+  rows?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * Reference to a column configuration.
+ */
+interface ColumnReference {
+  name: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Deep copies a value, handling undefined.
+ */
+function deepcopy<T>(value: T): T {
+  if (value === undefined) return undefined as T;
+  return JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * Rotates a 2D point around an origin.
+ * Uses the same convention as makerjs: angle in degrees, counter-clockwise.
+ */
+function rotatePoint2D(
+  point: [number, number],
+  angle: number,
+  origin: [number, number] = [0, 0]
+): [number, number] {
+  const rad = (angle * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const dx = point[0] - origin[0];
+  const dy = point[1] - origin[1];
+  return [origin[0] + dx * cos - dy * sin, origin[1] + dx * sin + dy * cos];
+}
+
+/**
+ * Point class representing a positioned point with rotation.
+ * Matches Ergogen's Point API for consistency.
+ */
+export class Point {
+  /** X position in mm */
+  x: number;
+  /** Y position in mm */
+  y: number;
+  /** Rotation in degrees */
+  r: number;
+  /** Metadata associated with this point */
+  meta: PointMeta;
+
+  /**
+   * Creates a new Point.
+   *
+   * @param x - X position or [x, y] array
+   * @param y - Y position (ignored if x is array)
+   * @param r - Rotation in degrees
+   * @param meta - Metadata object
+   */
+  constructor(
+    x: number | [number, number] = 0,
+    y: number = 0,
+    r: number = 0,
+    meta: PointMeta = {}
+  ) {
+    if (Array.isArray(x)) {
+      this.x = x[0];
+      this.y = x[1];
+      this.r = 0;
+      this.meta = {};
+    } else {
+      this.x = x;
+      this.y = y;
+      this.r = r;
+      this.meta = meta;
+    }
+  }
+
+  /**
+   * Gets the position as [x, y] array.
+   */
+  get p(): [number, number] {
+    return [this.x, this.y];
+  }
+
+  /**
+   * Sets the position from [x, y] array.
+   */
+  set p(val: [number, number]) {
+    [this.x, this.y] = val;
+  }
+
+  /**
+   * Shifts this point by the given offset.
+   *
+   * @param s - Shift amount [x, y]
+   * @param relative - If true, shift is relative to current rotation
+   * @param resist - If true, ignore mirroring for shift direction
+   * @returns This point for chaining
+   */
+  shift(
+    s: [number, number],
+    relative: boolean = true,
+    resist: boolean = false
+  ): this {
+    const shiftX = !resist && this.meta.mirrored ? -s[0] : s[0];
+    let shifted: [number, number] = [shiftX, s[1]];
+
+    if (relative) {
+      shifted = rotatePoint2D(shifted, this.r);
+    }
+
+    this.x += shifted[0];
+    this.y += shifted[1];
+    return this;
+  }
+
+  /**
+   * Rotates this point around an origin.
+   *
+   * @param angle - Rotation angle in degrees
+   * @param origin - Origin point [x, y] for rotation
+   * @param resist - If true, ignore mirroring for rotation direction
+   * @returns This point for chaining
+   */
+  rotate(
+    angle: number,
+    origin: [number, number] | false = [0, 0],
+    resist: boolean = false
+  ): this {
+    const effectiveAngle = !resist && this.meta.mirrored ? -angle : angle;
+
+    if (origin !== false) {
+      this.p = rotatePoint2D(this.p, effectiveAngle, origin);
+    }
+
+    this.r += effectiveAngle;
+    return this;
+  }
+
+  /**
+   * Mirrors this point across a vertical axis.
+   *
+   * @param x - X coordinate of the mirror axis
+   * @returns This point for chaining
+   */
+  mirror(x: number): this {
+    this.x = 2 * x - this.x;
+    this.r = -this.r;
+    return this;
+  }
+
+  /**
+   * Creates a deep clone of this point.
+   */
+  clone(): Point {
+    return new Point(this.x, this.y, this.r, deepcopy(this.meta));
+  }
+
+  /**
+   * Calculates the angle from this point to another.
+   *
+   * @param other - Target point
+   * @returns Angle in degrees
+   */
+  angle(other: Point): number {
+    const dx = other.x - this.x;
+    const dy = other.y - this.y;
+    return -Math.atan2(dx, dy) * (180 / Math.PI);
+  }
+
+  /**
+   * Checks if this point equals another.
+   *
+   * @param other - Point to compare
+   * @returns True if equal
+   */
+  equals(other: Point): boolean {
+    return (
+      this.x === other.x &&
+      this.y === other.y &&
+      this.r === other.r &&
+      JSON.stringify(this.meta) === JSON.stringify(other.meta)
+    );
+  }
+
+  /**
+   * Returns a rectangle positioned at this point.
+   * The rectangle is centered on the point.
+   *
+   * @param size - Size of the rectangle (width and height)
+   * @returns Array of corner points [[x1,y1], [x2,y2], [x3,y3], [x4,y4]]
+   */
+  rect(size: number = 14): [number, number][] {
+    const halfSize = size / 2;
+    // Corners relative to center, before rotation
+    const corners: [number, number][] = [
+      [-halfSize, -halfSize],
+      [halfSize, -halfSize],
+      [halfSize, halfSize],
+      [-halfSize, halfSize],
+    ];
+
+    // Rotate and translate each corner
+    return corners.map((corner) => {
+      const rotated = rotatePoint2D(corner, this.r, [0, 0]);
+      return [rotated[0] + this.x, rotated[1] + this.y];
+    });
+  }
+}

--- a/src/layout-editor/core/index.ts
+++ b/src/layout-editor/core/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Core module - Ergogen-aligned data structures for the layout editor.
+ */
+
+export { Point } from './Point';
+export { EditorPoint, UNIT_U, ERGOGEN_DEFAULTS, type KeyConfig } from './types';

--- a/src/layout-editor/core/types.ts
+++ b/src/layout-editor/core/types.ts
@@ -1,0 +1,145 @@
+/**
+ * Core types aligned with Ergogen's internal data structures.
+ *
+ * These types mirror Ergogen's configuration and runtime structures
+ * to ensure consistency between the visual editor and Ergogen output.
+ */
+
+import { Point, PointMeta } from './Point';
+
+/**
+ * Standard key unit in millimeters (1U = 19.05mm for MX switches).
+ * This is Ergogen's default 'U' unit.
+ */
+export const UNIT_U = 19.05;
+
+/**
+ * Ergogen default values matching src/units.js
+ */
+export const ERGOGEN_DEFAULTS = {
+  U: UNIT_U,
+  u: 19,
+  cx: 18,
+  cy: 17,
+  stagger: 0,
+  spread: 19, // u
+  splay: 0,
+  height: 18, // u-1 = 18
+  width: 18, // u-1 = 18
+  padding: 19, // u
+  autobind: 10,
+} as const;
+
+/**
+ * Key configuration matching Ergogen's key-level settings.
+ * These properties can be inherited from zone -> column -> row -> key.
+ */
+export interface KeyConfig {
+  /** Vertical offset (stagger) - inheritable */
+  stagger?: number;
+  /** Horizontal offset between columns (spread) - inheritable */
+  spread?: number;
+  /** Column rotation in degrees (splay) - inheritable */
+  splay?: number;
+  /** Origin for splay rotation [x, y] in mm - inheritable */
+  origin?: [number, number];
+  /** Key-level pre-rotation (orient) - inheritable */
+  orient?: number;
+  /** Key-level position adjustment [x, y] - inheritable */
+  shift?: [number, number];
+  /** Key-level post-rotation (rotate) - inheritable */
+  rotate?: number;
+  /** Key width in mm - inheritable */
+  width?: number;
+  /** Key height in mm - inheritable */
+  height?: number;
+  /** Distance to next key in column (padding) - inheritable */
+  padding?: number;
+  /** Whether to skip this key in output */
+  skip?: boolean;
+  /** Asymmetry setting for mirroring */
+  asym?: 'source' | 'clone' | 'both';
+  /** Auto-binding distance */
+  autobind?: number;
+  /** Manual bind values [top, right, bottom, left] */
+  bind?: number | [number, number] | [number, number, number, number];
+  /** Any additional custom properties */
+  [key: string]: unknown;
+}
+
+/**
+ * Extended Point metadata for editor use.
+ * Combines Ergogen's PointMeta with editor-specific properties.
+ */
+interface EditorPointMeta extends PointMeta {
+  /** Unique ID for React key purposes */
+  id: string;
+  /** Display color in the editor */
+  color?: string;
+  /** Whether this is a mirror of another point */
+  mirrorOf?: string;
+  /** Selection state in editor */
+  selected?: boolean;
+}
+
+/**
+ * Editor-specific Point class with additional functionality.
+ */
+export class EditorPoint extends Point {
+  /**
+   * Typed metadata for editor use.
+   * Override of Point.meta with EditorPointMeta type.
+   */
+  override meta: EditorPointMeta;
+
+  constructor(
+    x: number | [number, number] = 0,
+    y: number = 0,
+    r: number = 0,
+    meta: EditorPointMeta = { id: '' }
+  ) {
+    super(x, y, r, meta);
+    this.meta = meta;
+  }
+
+  /**
+   * Creates a deep clone with editor metadata.
+   */
+  override clone(): EditorPoint {
+    const cloned = super.clone();
+    return new EditorPoint(
+      cloned.x,
+      cloned.y,
+      cloned.r,
+      cloned.meta as EditorPointMeta
+    );
+  }
+
+  /**
+   * Gets the display width for this point.
+   */
+  get width(): number {
+    return this.meta.width ?? ERGOGEN_DEFAULTS.width;
+  }
+
+  /**
+   * Gets the display height for this point.
+   */
+  get height(): number {
+    return this.meta.height ?? ERGOGEN_DEFAULTS.height;
+  }
+
+  /**
+   * Gets the unique identifier.
+   */
+  get id(): string {
+    return this.meta.id;
+  }
+
+  /**
+   * Gets the display name.
+   */
+  get name(): string {
+    return this.meta.name ?? '';
+  }
+}

--- a/src/layout-editor/index.ts
+++ b/src/layout-editor/index.ts
@@ -9,4 +9,3 @@
 import { LayoutEditor } from './LayoutEditor';
 
 export { LayoutEditor };
-

--- a/src/layout-editor/types.ts
+++ b/src/layout-editor/types.ts
@@ -13,6 +13,9 @@
 // Import core types
 import { EditorPoint, UNIT_U, ERGOGEN_DEFAULTS, type KeyConfig } from './core';
 
+// Re-export ERGOGEN_DEFAULTS for use by other modules
+export { ERGOGEN_DEFAULTS };
+
 /**
  * Represents a single key in the layout editor.
  *

--- a/src/layout-editor/utils/layoutGenerator.ts
+++ b/src/layout-editor/utils/layoutGenerator.ts
@@ -1,188 +1,203 @@
-import { EditorZone, EditorKey, KEY_UNIT_MM, DEFAULT_KEY } from '../types';
+/**
+ * Layout Generator - Calculates key positions using Ergogen's positioning logic.
+ *
+ * This module implements Ergogen's point generation algorithm to ensure
+ * consistency between the visual editor and Ergogen's output.
+ *
+ * Key concepts from Ergogen:
+ * - Points accumulate transforms: spread moves along X, stagger along Y
+ * - Splay rotates around an origin point (cumulative)
+ * - Padding determines vertical spacing between rows
+ * - Zone anchors position the entire zone
+ */
+
+import { EditorZone, EditorKey, DEFAULT_KEY, ERGOGEN_DEFAULTS } from '../types';
+import { Point } from '../core';
 
 /**
- * Converts degrees to radians
+ * Rotation accumulator used for splay calculations.
+ * Matches Ergogen's rotation tracking structure.
  */
-function toRad(deg: number): number {
-  return (deg * Math.PI) / 180;
+interface Rotation {
+  angle: number;
+  origin: [number, number];
 }
 
 /**
- * Rotates a point around an origin
+ * Pushes a rotation to the accumulator.
+ * Used for cumulative splay calculations.
  */
-function rotatePoint(
-  x: number,
-  y: number,
+function pushRotation(
+  rotations: Rotation[],
   angle: number,
-  originX: number,
-  originY: number
-): { x: number; y: number } {
-  const rad = toRad(angle);
-  const cos = Math.cos(rad);
-  const sin = Math.sin(rad);
-  const dx = x - originX;
-  const dy = y - originY;
-  return {
-    x: originX + dx * cos - dy * sin,
-    y: originY + dx * sin + dy * cos,
-  };
+  origin: [number, number]
+): void {
+  if (angle !== 0) {
+    rotations.push({ angle, origin });
+  }
 }
 
 /**
- * Recalculates key positions for a zone based on its columns and rows.
- * Returns a map of key IDs to their new partial properties (x, y, rotation).
+ * Applies all accumulated rotations to a point.
+ */
+function applyRotations(point: Point, rotations: Rotation[]): void {
+  for (const r of rotations) {
+    point.rotate(r.angle, r.origin);
+  }
+}
+
+/**
+ * Recalculates key positions for a zone using Ergogen's positioning logic.
+ *
+ * This implements the same algorithm as Ergogen's render_zone function:
+ * 1. Start at zone anchor position
+ * 2. For each column:
+ *    - Apply spread (horizontal offset from previous column)
+ *    - Apply stagger (vertical offset)
+ *    - Apply splay (rotation around origin)
+ * 3. For each row in column:
+ *    - Copy column anchor
+ *    - Apply key-level transforms (orient, shift, rotate)
+ *    - Move to next row position (padding)
+ *
+ * @param zone - The zone configuration
+ * @param allKeys - Map of all keys in the layout
+ * @returns Map of key IDs to their updated properties
  */
 export function recalculateZone(
   zone: EditorZone,
   allKeys: Map<string, EditorKey>
 ): Map<string, Partial<EditorKey>> {
   const updates = new Map<string, Partial<EditorKey>>();
+
+  // Filter keys belonging to this zone
   const zoneKeys = Array.from(allKeys.values()).filter(
     (k) => k.zone === zone.name
   );
 
-  if (zoneKeys.length === 0) return updates;
-
-  // 1. Calculate column transforms
-  // Each column has a position (x, y) and rotation relative to the zone origin
-  const colTransforms: { x: number; y: number; rotation: number }[] = [];
-
-  // Re-loop with index to handle previous col
-
-  // Let's restart the loop with a cumulative transform approach
-  let x = 0;
-  let y = 0;
-  let rot = 0; // degrees
-
-  for (let i = 0; i < zone.columns.length; i++) {
-    const col = zone.columns[i];
-
-    // Apply stagger (vertical offset for THIS column)
-    // Stagger is usually relative to the "baseline" (y=0)
-    // So the column center is at (currentX, currentY + stagger)
-    // But we need to account for rotation.
-
-    // Let's assume the "spine" of the zone is calculated first, then stagger is applied.
-
-    // Position of the "spine" point for this column
-    const spineX = x;
-    const spineY = y;
-
-    // Apply splay for THIS column (rotation relative to previous)
-    // Usually splay is "rotate this column by X".
-    // So we add to cumulative rotation.
-    rot += col.splay;
-
-    // Calculate the actual column position (applying stagger)
-    // Stagger moves along the Y axis of the current rotation
-    const stagger = col.stagger * KEY_UNIT_MM; // mm
-
-    // Calculate position in mm
-    // We are at spineX, spineY. We rotate by rot. Then we move (0, stagger).
-    // Actually, stagger is usually just Y offset.
-
-    // Let's calculate the column's center in world space (mm)
-    // We start at [spineX, spineY] which is on the "baseline"
-    // We apply the cumulative rotation `rot`
-    // Then we apply the stagger offset (0, stagger) in the local rotated space
-
-    const colPos = rotatePoint(0, stagger, 0, 0, 0); // Just (0, stagger)
-    // Rotate this offset by the cumulative rotation
-    const rotatedOffset = rotatePoint(colPos.x, colPos.y, rot, 0, 0);
-
-    const finalColX = spineX + rotatedOffset.x;
-    const finalColY = spineY + rotatedOffset.y;
-
-    colTransforms.push({
-      x: finalColX,
-      y: finalColY,
-      rotation: rot,
-    });
-
-    // Prepare for next column
-    // Move by spread along the X axis of the CURRENT rotation
-    const spread = col.spread; // mm (default 19.05)
-
-    // Move (spread, 0) in local space, rotated by rot
-    const spreadOffset = rotatePoint(spread, 0, rot, 0, 0);
-
-    x += spreadOffset.x;
-    y += spreadOffset.y;
+  if (zoneKeys.length === 0) {
+    return updates;
   }
 
-  // 2. Iterate keys and apply transforms
-  zoneKeys.forEach((key) => {
-    // Find column and row index
-    // We rely on naming convention or metadata?
-    // The key object has `column` and `row` properties which are names (e.g. "col1", "row1")
+  // Initialize zone anchor
+  const zoneAnchor = new Point(
+    zone.anchor.shift[0],
+    zone.anchor.shift[1],
+    zone.anchor.rotate
+  );
 
-    const colIndex = zone.columns.findIndex((c) => c.name === key.column);
-    const rowIndex = zone.rows.findIndex((r) => r.name === key.row);
+  // Rotation accumulator for cumulative splay
+  const rotations: Rotation[] = [];
 
-    if (colIndex === -1 || rowIndex === -1) return;
+  let isFirstColumn = true;
 
-    const colTransform = colTransforms[colIndex];
+  // Process each column
+  for (const column of zone.columns) {
+    // Get column key configuration
+    const colKey = column.key;
+    const spread = colKey.spread ?? ERGOGEN_DEFAULTS.spread;
+    const stagger = colKey.stagger ?? ERGOGEN_DEFAULTS.stagger;
+    const splay = colKey.splay ?? ERGOGEN_DEFAULTS.splay;
+    const origin = colKey.origin ?? [0, 0];
 
-    // Calculate row offset
-    // Rows are usually just stacked vertically (negative Y)
-    // Row 0 is at 0. Row 1 is at -1u (or +1u depending on direction).
-    // Standard keyboard: rows go DOWN.
-    // In our editor, Y goes UP (positive).
-    // So "lower" rows (physically) have lower Y values.
-    // If row 0 is "top", row 1 is "below".
-    // Let's assume standard spacing of 19.05mm between rows.
-    // We need to know the visual order.
-    // Let's assume row index 0 is the "main" row (or top?), and others are offset.
-    // Actually, usually rows are defined from top to bottom or bottom to top.
-    // Let's assume simple 1u spacing for now: y = -rowIndex * 19.05
-    // But we should check if rows have their own props (padding/spread?).
-    // The `EditorRow` type has `ergogenProps`, but no explicit spacing.
-    // We'll assume standard 1u spacing.
+    // Apply spread (skip for first column)
+    if (!isFirstColumn) {
+      zoneAnchor.x += spread;
+    }
 
-    const rowOffset = -rowIndex * KEY_UNIT_MM;
+    // Apply stagger
+    zoneAnchor.y += stagger;
 
-    // Apply row offset in the column's local rotation
-    const keyOffset = rotatePoint(0, rowOffset, colTransform.rotation, 0, 0);
+    // Save column anchor position
+    const colAnchor = zoneAnchor.clone();
 
-    let keyX = colTransform.x + keyOffset.x;
-    let keyY = colTransform.y + keyOffset.y;
-    let keyRot = colTransform.rotation;
+    // Apply splay rotation (cumulative)
+    if (splay !== 0) {
+      // Splay origin is relative to current column position
+      const splayOrigin: [number, number] = [
+        colAnchor.x + origin[0],
+        colAnchor.y + origin[1],
+      ];
+      pushRotation(rotations, splay, splayOrigin);
+    }
 
-    // 3. Apply Zone Anchor & Rotation
-    // The calculated positions are relative to the zone origin (0,0).
-    // We need to apply the zone's anchor shift and rotation.
+    // Create running anchor for key positioning
+    let runningAnchor = colAnchor.clone();
 
-    // Apply zone rotation
-    const zoneRotated = rotatePoint(keyX, keyY, zone.rotate, 0, 0);
-    keyX = zoneRotated.x;
-    keyY = zoneRotated.y;
-    keyRot += zone.rotate;
+    // Apply all accumulated rotations
+    applyRotations(runningAnchor, rotations);
 
-    // Apply anchor shift
-    keyX += zone.anchor.shiftX;
-    keyY += zone.anchor.shiftY;
+    // Get default padding for this column
+    const defaultPadding = ERGOGEN_DEFAULTS.padding;
 
-    // Convert back to editor units (1u = 19.05mm)
-    // The editor stores x/y in units, not mm.
-    // But our calculations used mm (KEY_UNIT_MM).
-    // So we divide by KEY_UNIT_MM.
+    // Process each row in this column
+    for (const row of zone.rows) {
+      // Find the key at this column/row position
+      const key = zoneKeys.find(
+        (k) => k.column === column.name && k.row === row.name
+      );
 
-    const finalX = keyX / KEY_UNIT_MM;
-    const finalY = keyY / KEY_UNIT_MM;
+      if (!key) {
+        // No key at this position, but still advance running anchor
+        runningAnchor.shift([0, defaultPadding]);
+        continue;
+      }
 
-    updates.set(key.id, {
-      x: finalX,
-      y: finalY,
-      rotation: keyRot,
-    });
-  });
+      // Get row-level overrides from column config
+      const rowOverrides = column.rows[row.name] || {};
+
+      // Get key-level overrides
+      const keyOrient = (rowOverrides.orient as number) ?? 0;
+      const keyShift = (rowOverrides.shift as [number, number]) ?? [0, 0];
+      const keyRotate = (rowOverrides.rotate as number) ?? 0;
+      const keyPadding = (rowOverrides.padding as number) ?? defaultPadding;
+
+      // Copy running anchor for this key
+      const keyPoint = runningAnchor.clone();
+
+      // Apply key-level transforms (matching Ergogen's order)
+      keyPoint.r += keyOrient;
+      keyPoint.shift(keyShift);
+      keyPoint.r += keyRotate;
+
+      // Save key point (running anchor continues from here)
+      runningAnchor = keyPoint.clone();
+
+      // Apply zone-level rotation if present
+      if (zone.rotate !== 0) {
+        // Rotate around zone origin
+        keyPoint.rotate(zone.rotate, [
+          zone.anchor.shift[0],
+          zone.anchor.shift[1],
+        ]);
+      }
+
+      // Store the update
+      updates.set(key.id, {
+        x: keyPoint.x,
+        y: keyPoint.y,
+        rotation: keyPoint.r,
+      });
+
+      // Advance running anchor for next row
+      runningAnchor.shift([0, keyPadding]);
+    }
+
+    isFirstColumn = false;
+  }
 
   return updates;
 }
 
 /**
- * Generates missing keys for a zone based on its columns and rows.
- * Returns an array of new keys that need to be added.
+ * Generates missing keys for a zone based on its column and row configuration.
+ *
+ * Creates a key for each column/row combination that doesn't already exist.
+ *
+ * @param zone - The zone configuration
+ * @param existingKeys - Map of existing keys
+ * @param idGenerator - Function to generate unique IDs
+ * @returns Array of new keys to add
  */
 export function generateMissingKeys(
   zone: EditorZone,
@@ -190,16 +205,18 @@ export function generateMissingKeys(
   idGenerator: () => string
 ): EditorKey[] {
   const newKeys: EditorKey[] = [];
+
+  // Get existing keys for this zone
   const zoneKeys = Array.from(existingKeys.values()).filter(
     (k) => k.zone === zone.name
   );
 
-  // Iterate through all expected positions
-  zone.columns.forEach((col) => {
-    zone.rows.forEach((row) => {
-      // Check if a key exists for this col/row combination
+  // Iterate through all expected column/row combinations
+  for (const column of zone.columns) {
+    for (const row of zone.rows) {
+      // Check if a key exists at this position
       const exists = zoneKeys.some(
-        (k) => k.column === col.name && k.row === row.name
+        (k) => k.column === column.name && k.row === row.name
       );
 
       if (!exists) {
@@ -208,14 +225,148 @@ export function generateMissingKeys(
           ...DEFAULT_KEY,
           id,
           zone: zone.name,
-          column: col.name,
+          column: column.name,
           row: row.name,
-          name: `${zone.name}_${col.name}_${row.name}`,
+          name: `${zone.name}_${column.name}_${row.name}`,
+          // Inherit column-level settings
+          spread: column.key.spread,
+          stagger: column.key.stagger,
+          splay: column.key.splay,
+          rotationOrigin: column.key.origin,
         };
         newKeys.push(newKey);
       }
-    });
-  });
+    }
+  }
 
   return newKeys;
+}
+
+/**
+ * Renders all points for a zone, matching Ergogen's render_zone function.
+ *
+ * This is a more complete implementation that returns Point objects
+ * with full metadata, similar to Ergogen's output.
+ *
+ * @param zone - The zone configuration
+ * @param globalKey - Global key defaults (from points.key)
+ * @returns Map of point names to Point instances
+ */
+export function renderZonePoints(
+  zone: EditorZone,
+  globalKey: Partial<EditorKey> = {}
+): Map<string, Point> {
+  const points = new Map<string, Point>();
+
+  // Resolve zone-level key defaults (zone.key extends global.key)
+  const zoneKey = { ...globalKey, ...zone.key };
+
+  // Initialize zone anchor
+  const zoneAnchor = new Point(
+    zone.anchor.shift[0],
+    zone.anchor.shift[1],
+    zone.anchor.rotate
+  );
+
+  // Rotation accumulator
+  const rotations: Rotation[] = [];
+
+  let isFirstColumn = true;
+
+  for (const column of zone.columns) {
+    // Resolve column key (column.key extends zone.key)
+    const colKey = { ...zoneKey, ...column.key };
+
+    const spread = (colKey.spread as number) ?? ERGOGEN_DEFAULTS.spread;
+    const stagger = (colKey.stagger as number) ?? ERGOGEN_DEFAULTS.stagger;
+    const splay = (colKey.splay as number) ?? ERGOGEN_DEFAULTS.splay;
+    const origin = (colKey.origin as [number, number]) ?? [0, 0];
+
+    // Apply spread
+    if (!isFirstColumn) {
+      zoneAnchor.x += spread;
+    }
+
+    // Apply stagger
+    zoneAnchor.y += stagger;
+
+    const colAnchor = zoneAnchor.clone();
+
+    // Apply splay
+    if (splay !== 0) {
+      const splayOrigin: [number, number] = [
+        colAnchor.x + origin[0],
+        colAnchor.y + origin[1],
+      ];
+      pushRotation(rotations, splay, splayOrigin);
+    }
+
+    let runningAnchor = colAnchor.clone();
+    applyRotations(runningAnchor, rotations);
+
+    for (const row of zone.rows) {
+      // Resolve row key (row extends column)
+      const rowOverrides = column.rows[row.name] || {};
+      const rowKey = { ...colKey, ...row.key, ...rowOverrides };
+
+      const orient = (rowKey.orient as number) ?? 0;
+      const shift = (rowKey.shift as [number, number]) ?? [0, 0];
+      const rotate = (rowKey.rotate as number) ?? 0;
+      const padding = (rowKey.padding as number) ?? ERGOGEN_DEFAULTS.padding;
+      const width = (rowKey.width as number) ?? ERGOGEN_DEFAULTS.width;
+      const height = (rowKey.height as number) ?? ERGOGEN_DEFAULTS.height;
+      const skip = (rowKey.skip as boolean) ?? false;
+      const asym = (rowKey.asym as 'source' | 'clone' | 'both') ?? 'both';
+
+      // Calculate key point
+      const keyPoint = runningAnchor.clone();
+
+      keyPoint.r += orient;
+      keyPoint.shift(shift);
+      keyPoint.r += rotate;
+
+      runningAnchor = keyPoint.clone();
+
+      // Apply zone rotation
+      if (zone.rotate !== 0) {
+        keyPoint.rotate(zone.rotate, [
+          zone.anchor.shift[0],
+          zone.anchor.shift[1],
+        ]);
+      }
+
+      // Set metadata
+      const keyName = `${zone.name}_${column.name}_${row.name}`;
+      keyPoint.meta = {
+        name: keyName,
+        zone: { name: zone.name },
+        col: { name: column.name },
+        row: row.name,
+        colrow: `${column.name}_${row.name}`,
+        width,
+        height,
+        stagger,
+        spread,
+        splay,
+        origin,
+        orient,
+        shift,
+        rotate,
+        padding,
+        skip,
+        asym,
+      };
+
+      if (!skip) {
+        points.set(keyName, keyPoint);
+      }
+
+      // Advance for next row
+      runningAnchor.shift([0, padding]);
+    }
+
+    isFirstColumn = false;
+  }
+
+  return points;
 }


### PR DESCRIPTION
Refactor the layout editor's internal keyboard representation to use Ergogen's `Point` class and data structures to ensure rendering and positioning consistency.

Previously, the editor's internal model was based on KLE, which could lead to discrepancies between the visual editor and Ergogen's final output. This change directly integrates Ergogen's geometric primitives and data flow into the editor's core, ensuring that key positions and rotations are calculated using the same logic as Ergogen itself.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b07f919-1b75-4de1-a000-c052d1b80fad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b07f919-1b75-4de1-a000-c052d1b80fad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

