### PR TITLE
🧪 Add unit tests for trackEvent analytics function

### DIFF
--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -1,0 +1,56 @@
+import { trackEvent } from './analytics';
+
+describe('trackEvent', () => {
+  const originalGtag = window.gtag;
+
+  beforeEach(() => {
+    // Reset window.gtag before each test
+    window.gtag = jest.fn();
+  });
+
+  afterAll(() => {
+    // Restore original window.gtag
+    window.gtag = originalGtag;
+  });
+
+  it('should call window.gtag when it is defined', () => {
+    const eventName = 'test_event';
+    const eventParams = { param1: 'value1', param2: 123 };
+
+    trackEvent(eventName, eventParams);
+
+    expect(window.gtag).toHaveBeenCalledWith('event', eventName, {
+      event_category: 'user_action',
+      param1: 'value1',
+      param2: 123,
+    });
+  });
+
+  it('should call window.gtag with default category when eventParams is not provided', () => {
+    const eventName = 'test_event';
+
+    trackEvent(eventName);
+
+    expect(window.gtag).toHaveBeenCalledWith('event', eventName, {
+      event_category: 'user_action',
+    });
+  });
+
+  it('should allow overriding event_category', () => {
+    const eventName = 'test_event';
+    const eventParams = { event_category: 'custom_category' };
+
+    trackEvent(eventName, eventParams);
+
+    expect(window.gtag).toHaveBeenCalledWith('event', eventName, {
+      event_category: 'custom_category',
+    });
+  });
+
+  it('should not throw or call anything when window.gtag is undefined', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).gtag = undefined;
+
+    expect(() => trackEvent('test_event')).not.toThrow();
+  });
+});


### PR DESCRIPTION
🎯 **What:** The trackEvent function in src/utils/analytics.ts was previously untested.
📊 **Coverage:**
- Verified that window.gtag is called with the correct arguments when defined.
- Verified that default parameters are correctly applied.
- Verified that event_category can be overridden.
- Verified that the function handles cases where window.gtag is missing.
✨ **Result:** Improved test coverage for utility functions.

---
*PR created automatically by Jules for task [2721380207969198503](https://jules.google.com/task/2721380207969198503) started by @ceoloide*