### PR TITLE
🧪 Add unit and integration tests for GitHub rate limiting logic

### DIFF
--- a/src/utils/github.test.ts
+++ b/src/utils/github.test.ts
@@ -1,4 +1,4 @@
-import { fetchConfigFromUrl } from './github';
+import { fetchConfigFromUrl, checkRateLimit } from './github';
 
 // Mock fetch globally
 global.fetch = jest.fn();
@@ -14,63 +14,37 @@ describe('github utilities', () => {
       const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
 
       // Mock config.yaml fetch from root (404)
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response('', { status: 404 }) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response('', { status: 404 }));
 
       // Mock config.yaml fetch from ergogen folder (success)
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response('points: {}', { status: 200 }) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response('points: {}', { status: 200 }));
 
       // Mock footprints directory (empty)
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response('[]', { status: 404 }) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response('[]', { status: 404 }));
 
       // Mock .gitmodules fetch
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(
-            '[submodule "ergogen/footprints/ceoloide"]\n' +
-              '\tpath = ergogen/footprints/ceoloide\n' +
-              '\turl = https://github.com/ceoloide/ergogen-footprints.git',
-            { status: 200 }
-          ) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response(
+        '[submodule "ergogen/footprints/ceoloide"]\n' +
+          '\tpath = ergogen/footprints/ceoloide\n' +
+          '\turl = https://github.com/ceoloide/ergogen-footprints.git',
+        { status: 200 }
+      ));
 
       // Mock submodule repo contents (main branch)
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(
-            JSON.stringify([
-              {
-                type: 'file',
-                name: 'test_footprint.js',
-                download_url:
-                  'https://raw.githubusercontent.com/ceoloide/ergogen-footprints/main/test_footprint.js',
-              },
-            ]),
-            { status: 200 }
-          ) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response(
+        JSON.stringify([
+          {
+            type: 'file',
+            name: 'test_footprint.js',
+            download_url:
+              'https://raw.githubusercontent.com/ceoloide/ergogen-footprints/main/test_footprint.js',
+          },
+        ]),
+        { status: 200 }
+      ));
 
       // Mock footprint file content
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response('module.exports = {}', {
-            status: 200,
-          }) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response('module.exports = {}', { status: 200 }));
 
       // Act
       const result = await fetchConfigFromUrl('ceoloide/test-repo');
@@ -87,72 +61,46 @@ describe('github utilities', () => {
       const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
 
       // Mock config.yaml fetch
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response('points: {}', { status: 200 }) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response('points: {}', { status: 200 }));
 
       // Mock footprints directory (empty)
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response('[]', { status: 404 }) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response('[]', { status: 404 }));
 
       // Mock .gitmodules fetch
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(
-            '[submodule "footprints/external"]\n' +
-              '\tpath = footprints/external\n' +
-              '\turl = https://github.com/test/footprints.git',
-            { status: 200 }
-          ) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response(
+        '[submodule "footprints/external"]\n' +
+          '\tpath = footprints/external\n' +
+          '\turl = https://github.com/test/footprints.git',
+        { status: 200 }
+      ));
 
       // Mock submodule repo root contents
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(
-            JSON.stringify([
-              {
-                type: 'dir',
-                name: 'switches',
-                url: 'https://api.github.com/repos/test/footprints/contents/switches',
-              },
-            ]),
-            { status: 200 }
-          ) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response(
+        JSON.stringify([
+          {
+            type: 'dir',
+            name: 'switches',
+            url: 'https://api.github.com/repos/test/footprints/contents/switches',
+          },
+        ]),
+        { status: 200 }
+      ));
 
       // Mock submodule subdirectory contents
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(
-            JSON.stringify([
-              {
-                type: 'file',
-                name: 'mx.js',
-                download_url:
-                  'https://raw.githubusercontent.com/test/footprints/main/switches/mx.js',
-              },
-            ]),
-            { status: 200 }
-          ) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response(
+        JSON.stringify([
+          {
+            type: 'file',
+            name: 'mx.js',
+            download_url:
+              'https://raw.githubusercontent.com/test/footprints/main/switches/mx.js',
+          },
+        ]),
+        { status: 200 }
+      ));
 
       // Mock footprint file content
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response('module.exports = {}', {
-            status: 200,
-          }) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response('module.exports = {}', { status: 200 }));
 
       // Act
       const result = await fetchConfigFromUrl('test/repo');
@@ -167,30 +115,18 @@ describe('github utilities', () => {
       const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
 
       // Mock config.yaml fetch
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response('points: {}', { status: 200 }) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response('points: {}', { status: 200 }));
 
       // Mock footprints directory (empty)
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response('[]', { status: 404 }) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response('[]', { status: 404 }));
 
       // Mock .gitmodules fetch with non-footprint submodule
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response(
-            '[submodule "docs"]\n' +
-              '\tpath = docs\n' +
-              '\turl = https://github.com/test/docs.git',
-            { status: 200 }
-          ) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response(
+        '[submodule "docs"]\n' +
+          '\tpath = docs\n' +
+          '\turl = https://github.com/test/docs.git',
+        { status: 200 }
+      ));
 
       // Act
       const result = await fetchConfigFromUrl('test/repo');
@@ -204,25 +140,13 @@ describe('github utilities', () => {
       const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
 
       // Mock config.yaml fetch
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response('points: {}', { status: 200 }) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response('points: {}', { status: 200 }));
 
       // Mock footprints directory (empty)
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response('[]', { status: 404 }) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response('[]', { status: 404 }));
 
       // Mock .gitmodules fetch (404)
-      mockFetch.mockImplementationOnce(() =>
-        Promise.resolve(
-          new Response('', { status: 404 }) as unknown as Response
-        )
-      );
+      mockFetch.mockResolvedValueOnce(new Response('', { status: 404 }));
 
       // Act
       const result = await fetchConfigFromUrl('test/repo');
@@ -230,6 +154,94 @@ describe('github utilities', () => {
       // Assert
       expect(result.footprints).toHaveLength(0);
       expect(result.config).toBe('points: {}');
+    });
+  });
+
+  describe('checkRateLimit', () => {
+    const rawUrl = 'https://raw.githubusercontent.com/user/repo/main/config.yaml';
+    const apiUrl = 'https://api.github.com/repos/user/repo/contents/config.yaml';
+
+    it('should identify rate limit exceeded for raw content (HTTP 429)', () => {
+      const response = new Response(null, { status: 429 });
+      const result = checkRateLimit(response, rawUrl);
+      expect(result.isLimitExceeded).toBe(true);
+      expect(result.error).toContain('30 minutes');
+    });
+
+    it('should identify rate limit exceeded for API (HTTP 403 and remaining 0)', () => {
+      const response = new Response(null, {
+        status: 403,
+        headers: {
+          'X-RateLimit-Limit': '60',
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Used': '60',
+          'X-RateLimit-Reset': '1234567890'
+        }
+      });
+      const result = checkRateLimit(response, apiUrl);
+      expect(result.isLimitExceeded).toBe(true);
+      expect(result.error).toContain("You've used your hourly request allowance");
+    });
+
+    it('should identify approaching rate limit for API (80% used)', () => {
+      const response = new Response(null, {
+        status: 200,
+        headers: {
+          'X-RateLimit-Limit': '100',
+          'X-RateLimit-Remaining': '20',
+          'X-RateLimit-Used': '80',
+          'X-RateLimit-Reset': '1234567890'
+        }
+      });
+      const result = checkRateLimit(response, apiUrl);
+      expect(result.isLimitExceeded).toBe(false);
+      expect(result.error).toContain('Loading from GitHub may become unavailable soon');
+    });
+
+    it('should handle missing headers gracefully', () => {
+      const response = new Response(null, { status: 200 });
+      const result = checkRateLimit(response, apiUrl);
+      expect(result.isLimitExceeded).toBe(false);
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe('fetchConfigFromUrl rate limit integration', () => {
+    it('should throw error when rate limit is exceeded on all branches', async () => {
+      // Arrange
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+
+      // Mock all fetch calls to fail with 429 (raw content)
+      mockFetch.mockResolvedValue(new Response(null, { status: 429 }));
+
+      // Act & Assert
+      await expect(fetchConfigFromUrl('test/repo')).rejects.toThrow(/You've reached your hourly request allowance/);
+    });
+
+    it('should return rate limit warning when approaching limit', async () => {
+      // Arrange
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+
+      // Default mock for any API call: return 404 with warning headers
+      mockFetch.mockResolvedValue(new Response('[]', {
+        status: 404,
+        headers: {
+          'X-RateLimit-Limit': '100',
+          'X-RateLimit-Remaining': '20',
+          'X-RateLimit-Used': '80',
+          'X-RateLimit-Reset': '1234567890'
+        }
+      }));
+
+      // Specifically return config for the first call (main branch root config, raw URL)
+      mockFetch.mockResolvedValueOnce(new Response('points: {}', { status: 200 }));
+
+      // Act
+      const result = await fetchConfigFromUrl('test/repo');
+
+      // Assert
+      expect(result.config).toBe('points: {}');
+      expect(result.rateLimitWarning).toContain('Loading from GitHub may become unavailable soon');
     });
   });
 });

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -18,7 +18,7 @@ const getRawUrl = (url: string) => {
  * @param {string} url - The URL being fetched (to determine if it's API or raw content).
  * @returns {{isLimitExceeded: boolean, error: string | null}} Rate limit status.
  */
-const checkRateLimit = (
+export const checkRateLimit = (
   response: Response,
   url: string
 ): { isLimitExceeded: boolean; error: string | null } => {


### PR DESCRIPTION
🎯 **What:** This PR adds comprehensive unit and integration tests for the GitHub rate limiting logic in `src/utils/github.ts`.

📊 **Coverage:**
- Unit tests for `checkRateLimit`:
  - `raw.githubusercontent.com` rate limits (HTTP 429).
  - `api.github.com` rate limits (HTTP 403, `X-RateLimit-Remaining: 0`).
  - Warning threshold for API usage (80% used).
  - Graceful handling of missing headers and normal responses.
- Integration tests for `fetchConfigFromUrl`:
  - Propagation of rate limit errors.
  - Inclusion of rate limit warnings in the result.

✨ **Result:** Increased reliability of GitHub content loading by ensuring rate limiting scenarios are correctly identified and communicated to the user. All 151 unit tests in the project now pass.

---
*PR created automatically by Jules for task [14862536907537810082](https://jules.google.com/task/14862536907537810082) started by @ceoloide*