### PR TITLE
🧪 [testing improvement] Add tests for platform detection utilities

### DIFF
--- a/src/utils/platform.test.ts
+++ b/src/utils/platform.test.ts
@@ -1,0 +1,179 @@
+import { isMacOS, isWindows, isLinux, getPlatform, getModifierKey, isMobile } from './platform';
+
+describe('platform utilities', () => {
+  const originalNavigator = { ...global.navigator };
+
+  beforeEach(() => {
+    // Reset navigator before each test
+    Object.defineProperty(global, 'navigator', {
+      value: { ...originalNavigator },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterAll(() => {
+    // Restore original navigator
+    Object.defineProperty(global, 'navigator', {
+      value: originalNavigator,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  describe('isMacOS', () => {
+    it('returns true when userAgentData platform is macOS', () => {
+      Object.defineProperty(global.navigator, 'userAgentData', {
+        value: { platform: 'macOS' },
+        configurable: true,
+      });
+      expect(isMacOS()).toBe(true);
+    });
+
+    it('returns true when userAgent contains Mac', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+        configurable: true,
+      });
+      expect(isMacOS()).toBe(true);
+    });
+
+    it('returns false for other platforms', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        configurable: true,
+      });
+      expect(isMacOS()).toBe(false);
+    });
+  });
+
+  describe('isWindows', () => {
+    it('returns true when userAgentData platform is Windows', () => {
+      Object.defineProperty(global.navigator, 'userAgentData', {
+        value: { platform: 'Win32' },
+        configurable: true,
+      });
+      expect(isWindows()).toBe(true);
+    });
+
+    it('returns true when userAgent contains Win', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        configurable: true,
+      });
+      expect(isWindows()).toBe(true);
+    });
+
+    it('returns false for other platforms', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+        configurable: true,
+      });
+      expect(isWindows()).toBe(false);
+    });
+  });
+
+  describe('isLinux', () => {
+    it('returns true when userAgentData platform is Linux', () => {
+      Object.defineProperty(global.navigator, 'userAgentData', {
+        value: { platform: 'Linux x86_64' },
+        configurable: true,
+      });
+      expect(isLinux()).toBe(true);
+    });
+
+    it('returns true when userAgent contains Linux', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (X11; Linux x86_64)',
+        configurable: true,
+      });
+      expect(isLinux()).toBe(true);
+    });
+
+    it('returns false for other platforms', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        configurable: true,
+      });
+      expect(isLinux()).toBe(false);
+    });
+  });
+
+  describe('getPlatform', () => {
+    it('returns "mac" for macOS', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+        configurable: true,
+      });
+      expect(getPlatform()).toBe('mac');
+    });
+
+    it('returns "windows" for Windows', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        configurable: true,
+      });
+      expect(getPlatform()).toBe('windows');
+    });
+
+    it('returns "linux" for Linux', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (X11; Linux x86_64)',
+        configurable: true,
+      });
+      expect(getPlatform()).toBe('linux');
+    });
+
+    it('returns "other" for unknown platform', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Unknown Browser',
+        configurable: true,
+      });
+      expect(getPlatform()).toBe('other');
+    });
+  });
+
+  describe('getModifierKey', () => {
+    it('returns "⌘" for macOS', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+        configurable: true,
+      });
+      expect(getModifierKey()).toBe('⌘');
+    });
+
+    it('returns "Ctrl" for other platforms', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        configurable: true,
+      });
+      expect(getModifierKey()).toBe('Ctrl');
+    });
+  });
+
+  describe('isMobile', () => {
+    it('returns true for Android user agent', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Linux; Android 10; SM-G973F)',
+        configurable: true,
+      });
+      expect(isMobile()).toBe(true);
+    });
+
+    it('returns true for iPhone user agent', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X)',
+        configurable: true,
+      });
+      expect(isMobile()).toBe(true);
+    });
+
+    it('returns false for desktop user agent', () => {
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        configurable: true,
+      });
+      expect(isMobile()).toBe(false);
+    });
+  });
+});

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -20,7 +20,7 @@ export function isMacOS() {
   return false;
 }
 
-function isWindows() {
+export function isWindows() {
   if (typeof navigator !== 'undefined') {
     if ('userAgentData' in navigator && navigator.userAgentData) {
       const uaData = navigator.userAgentData as { platform?: string };
@@ -33,7 +33,7 @@ function isWindows() {
   return false;
 }
 
-function isLinux() {
+export function isLinux() {
   if (typeof navigator !== 'undefined') {
     if ('userAgentData' in navigator && navigator.userAgentData) {
       const uaData = navigator.userAgentData as { platform?: string };
@@ -46,18 +46,18 @@ function isLinux() {
   return false;
 }
 
-function _getPlatform() {
+export function getPlatform() {
   if (isMacOS()) return 'mac';
   if (isWindows()) return 'windows';
   if (isLinux()) return 'linux';
   return 'other';
 }
 
-function _getModifierKey() {
+export function getModifierKey() {
   return isMacOS() ? '⌘' : 'Ctrl';
 }
 
-function _isMobile() {
+export function isMobile() {
   if (typeof navigator !== 'undefined') {
     return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
       navigator.userAgent


### PR DESCRIPTION
Implemented comprehensive unit tests for platform detection utilities in \`src/utils/platform.ts\`. 
To facilitate testing, the following changes were made:
- Exported \`isWindows\` and \`isLinux\` functions.
- Renamed and exported internal utility functions: \`_getPlatform\` -> \`getPlatform\`, \`_getModifierKey\` -> \`getModifierKey\`, and \`_isMobile\` -> \`isMobile\`.

The new test suite \`src/utils/platform.test.ts\` covers modern \`userAgentData\` detection, legacy \`userAgent\` fallbacks, modifier keys, and mobile device detection. 
All 18 new tests pass, and no regressions were introduced.

---
*PR created automatically by Jules for task [9877905282931361447](https://jules.google.com/task/9877905282931361447) started by @ceoloide*