### PR TITLE
🧹 refactor: remove unused export VersionInfo in version.ts

### DIFF
--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,6 +1,6 @@
 import ergogenPkg from 'ergogen/package.json';
 
-export interface VersionInfo {
+interface VersionInfo {
   label: string;
   url: string;
 }


### PR DESCRIPTION
The `VersionInfo` interface was only used within `src/utils/version.ts` as the return type for `getErgogenVersionInfo`. Making it internal improves code health by reducing the public API surface area. Verified with `tsc --noEmit`, `eslint`, and `yarn test:unit`.

---
*PR created automatically by Jules for task [2657077231653742247](https://jules.google.com/task/2657077231653742247) started by @ceoloide*