### PR TITLE
Recent Configurations Preview ("Pick up where you left")

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,3 @@
 node_modules
 build
+test-results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Recent Configurations Preview (Pick up where you left)
+
+July 06, 2026
+
+![The welcome page showing the new Recent Configurations section displaying visual layouts of your recently edited keyboards.](./public/images/changelog/placeholder.png)
+
+When launching the Ergogen Web UI, returning to your active projects meant manually browsing the side panel search or opening layouts one by one to check their visual shapes. There was no visual "dashboard" to quickly identify and resume working on your most recently edited designs from the entry page.
+
+Now, a new "Pick up where you left" section greets you directly on the welcome page, showcasing up to 4 of your most recently edited configurations. Each layout is rendered as a visual preview card showing the compiled board shape alongside its name. Under the hood, multi-config storage has been upgraded to version 2 to embed clean, dark-themed SVG previews, which are compiled in the background for your legacy layouts to ensure your dashboard is immediately complete and responsive.
+
+**What changed:**
+
+- **Dashboard Recent Section**: Added a "Pick up where you left" section to the welcome page displaying cards for the 4 most recently modified keyboards
+- **Visual Previews**: Show the compiled keyboard shape inline on each card with a dark style matching the examples
+- **Fallback Glyph**: Center a `keyboard_off` icon on the card if a configuration is empty or fails to compile
+- **Background Compiler**: Automatically generate preview SVGs in the background for all legacy and version 1 configurations without blocking the UI or running heavy STL conversions
+- **Storage Version 2**: Upgraded the multi-configuration schema to version 2 to store formatted preview SVGs in local storage
+
 ## Multi-Configuration Management System
 
 July 06, 2026

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -341,6 +341,8 @@ The application features a built-in Multi-Configuration Management system allowi
 2. **Persistence (`constants.ts`)**:
    - Key name: `ergogen:multi-config` maps to a JSON container following the `MultiConfigContainer` scheme.
    - Automatically migrates legacy configurations (saved on `LOCAL_STORAGE_CONFIG` or `ergogen:config` key) on startup.
+   - **Version 2**: Upgraded to store formatted inline SVG previews (`previewSvg`) in `SavedConfig` metadata inside `ergogen:multi-config`.
+   - **Background Compilation**: Triggers a silent compile on mount for all configurations that lack a preview SVG (e.g. legacy/v1 designs) to generate their SVGs, skipping the heavy STL generation phase.
 3. **ZIP Exporter Utilities (`zip.ts`)**:
    - Offers background worker compilation sequences that compiles all configurations concurrently or sequentially and zips them up into a single file with custom folder structures.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ergogen-gui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A web-based GUI for Ergogen, the ergonomic keyboard layout generator.",
   "license": "MIT",
   "private": false,

--- a/public/dependencies/ergogen.js
+++ b/public/dependencies/ergogen.js
@@ -278,7 +278,6 @@
 			            }
 			        }
 			        let shape = combined;
-			        shape = m.model.mirror(shape, false, true);
 
 			        if (origin[0] !== 0 || origin[1] !== 0) {
 			            shape = m.model.moveRelative(shape, [-origin[0], -origin[1]]);
@@ -1816,7 +1815,12 @@
 		    const paths = [
 		        "M 7.1 0.7 A 1.5 1.5 0 0 0 8.6 2.2 L 11.6 2.2 L 11.6 3.15 L 14.2 3.15 L 14.2 5.75 L 11.6 5.75 L 11.6 6.7 L 7.6 6.7 L 7.6 5.2 A 0.5 0.5 0 0 0 7.1 4.7 L 2.6 4.7 L 2.6 3.5 L 0 3.5 L 0 0.95 L 2.6 0.95 L 2.6 0 L 7.1 0 L 7.1 0.7 Z"
 		    ];
-		    return u.svg_paths_to_outline(paths, config, name, points, outlines, units);
+		    let new_origin = [9.6,1.5];
+		    if (config && config.origin) {
+		        new_origin[0] += config.origin[0] || 0;
+		        new_origin[1] += config.origin[1] || 0;
+		    }
+		    return u.svg_paths_to_outline(paths, {...config, origin: new_origin}, name, points, outlines, units);
 		};
 		return choc_hotswap_socket;
 	}

--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto&display=swap">
   <link rel="stylesheet"
-    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0&family=Nunito:wght@300;400;500;600;700&icon_names=add,add_2,archive,close,collapse_content,delete,description,download,edit,expand_content,keyboard,keyboard_alt,refresh,settings,visibility" />
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0&family=Nunito:wght@300;400;500;600;700&icon_names=add,add_2,archive,close,collapse_content,delete,description,download,edit,expand_content,keyboard,keyboard_alt,keyboard_off,refresh,settings,visibility" />
   <title>Ergogen</title>
   <style>
     html,

--- a/src/context/ConfigContext.test.tsx
+++ b/src/context/ConfigContext.test.tsx
@@ -840,5 +840,163 @@ describe('ConfigContextProvider', () => {
       // The newest remaining should be `Config 104`
       expect(backupAfterPruningData2.configs[99].name).toBe('Config 104');
     });
+
+    it('should upgrade version 1 to version 2 on load and trigger background generation for configurations missing preview SVG', async () => {
+      // Setup version 1 container in localStorage with a configuration that lacks previewSvg
+      const initialConfigs = [
+        {
+          id: 'cfg-v1-1',
+          name: 'V1 Config',
+          config: 'points: {A: {}}',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ];
+      const containerV1 = {
+        version: 1,
+        activeConfigId: 'cfg-v1-1',
+        configs: initialConfigs,
+      };
+      localStorage.setItem('ergogen:multi-config', JSON.stringify(containerV1));
+
+      const TestComponent = () => {
+        useConfigContext();
+        return null;
+      };
+
+      mockErgogenWorker.postMessage.mockClear();
+
+      render(
+        <ConfigContextProvider>
+          <TestComponent />
+        </ConfigContextProvider>
+      );
+
+      // Verify it updates key in local storage to version 2
+      const storedRaw = localStorage.getItem('ergogen:multi-config');
+      expect(storedRaw).not.toBeNull();
+      const parsed = JSON.parse(storedRaw!);
+      expect(parsed.version).toBe(2);
+
+      // Verify that background-preview generation was triggered
+      expect(mockErgogenWorker.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'generate',
+          inputConfig: 'points: {A: {}}',
+          requestId: 'background-preview-cfg-v1-1',
+        })
+      );
+    });
+
+    it('should process background generation worker success message and update previewSvg in local storage without triggering STL conversion', () => {
+      const TestComponent = () => {
+        useConfigContext();
+        return null;
+      };
+
+      // Pre-populate multi-config
+      const initialConfigs = [
+        {
+          id: 'cfg-bg-1',
+          name: 'BG Config',
+          config: 'points: {A: {}}',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ];
+      const containerV2 = {
+        version: 2,
+        activeConfigId: 'cfg-bg-1',
+        configs: initialConfigs,
+      };
+      localStorage.setItem('ergogen:multi-config', JSON.stringify(containerV2));
+
+      mockJscadWorker.postMessage.mockClear();
+
+      render(
+        <ConfigContextProvider>
+          <TestComponent />
+        </ConfigContextProvider>
+      );
+
+      // Simulate worker success callback for background preview
+      act(() => {
+        mockErgogenWorker.onmessage({
+          data: {
+            type: 'success',
+            requestId: 'background-preview-cfg-bg-1',
+            results: {
+              demo: {
+                svg: '<svg><path stroke="#000" /></svg>',
+              },
+            },
+            warnings: [],
+          },
+        } as MessageEvent);
+      });
+
+      // Verify that previewSvg was formatted and stored
+      const stored = JSON.parse(localStorage.getItem('ergogen:multi-config')!);
+      expect(stored.configs[0].previewSvg).toContain(
+        'style="background-color: rgb(51,51,51);"'
+      );
+      expect(stored.configs[0].previewSvg).toContain('stroke="#AAA"');
+
+      // Verify that JSCAD/STL converter was NOT called
+      expect(mockJscadWorker.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('should save formatted previewSvg to the active configuration when user-initiated generation completes successfully', () => {
+      const TestComponent = () => {
+        useConfigContext();
+        return null;
+      };
+
+      // Pre-populate multi-config with active config
+      const initialConfigs = [
+        {
+          id: 'cfg-user-1',
+          name: 'User Config',
+          config: 'points: {A: {}}',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ];
+      const containerV2 = {
+        version: 2,
+        activeConfigId: 'cfg-user-1',
+        configs: initialConfigs,
+      };
+      localStorage.setItem('ergogen:multi-config', JSON.stringify(containerV2));
+
+      render(
+        <ConfigContextProvider>
+          <TestComponent />
+        </ConfigContextProvider>
+      );
+
+      // Simulate worker success callback for normal generation
+      act(() => {
+        mockErgogenWorker.onmessage({
+          data: {
+            type: 'success',
+            requestId: 'ergogen-generate-12345',
+            results: {
+              demo: {
+                svg: '<svg><path stroke="#000" /></svg>',
+              },
+            },
+            warnings: [],
+          },
+        } as MessageEvent);
+      });
+
+      // Verify that previewSvg was formatted and stored for user config
+      const stored = JSON.parse(localStorage.getItem('ergogen:multi-config')!);
+      expect(stored.configs[0].previewSvg).toContain(
+        'style="background-color: rgb(51,51,51);"'
+      );
+      expect(stored.configs[0].previewSvg).toContain('stroke="#AAA"');
+    });
   });
 });

--- a/src/context/ConfigContext.tsx
+++ b/src/context/ConfigContext.tsx
@@ -302,7 +302,7 @@ const pruneDeletedConfigs = () => {
 
 const formatPreviewSvg = (svgContent: unknown): string | undefined => {
   if (!svgContent) return undefined;
-  
+
   let content: string = '';
   if (typeof svgContent === 'string') {
     content = svgContent;

--- a/src/context/ConfigContext.tsx
+++ b/src/context/ConfigContext.tsx
@@ -41,6 +41,7 @@ interface SavedConfig {
   config: string;
   createdAt: string;
   updatedAt: string;
+  previewSvg?: string;
 }
 
 interface MultiConfigContainer {
@@ -299,9 +300,33 @@ const pruneDeletedConfigs = () => {
   }
 };
 
+const formatPreviewSvg = (svgContent: unknown): string | undefined => {
+  if (!svgContent) return undefined;
+  
+  let content: string = '';
+  if (typeof svgContent === 'string') {
+    content = svgContent;
+  } else if (Array.isArray(svgContent)) {
+    content = svgContent.join('');
+  } else {
+    return undefined;
+  }
+
+  content = content
+    .replace(/width="[^"]+"/, 'width="284px"')
+    .replace(/height="[^"]+"/, 'height="134px"');
+  content = content.replace(
+    /<svg/,
+    '<svg style="background-color: rgb(51,51,51);"'
+  );
+  content = content.replaceAll(/stroke="#000"/g, 'stroke="#AAA"');
+  content = content.replaceAll(/stroke:#000/g, 'stroke:#AAA');
+  return content;
+};
+
 const loadMultiConfigFromStorage = (): MultiConfigContainer => {
   if (typeof window === 'undefined') {
-    return { version: 1, activeConfigId: null, configs: [] };
+    return { version: 2, activeConfigId: null, configs: [] };
   }
   const stored = localStorage.getItem(MULTI_CONFIG_STORAGE_KEY);
   if (stored) {
@@ -326,7 +351,7 @@ const loadMultiConfigFromStorage = (): MultiConfigContainer => {
     }
   }
   return {
-    version: 1,
+    version: 2,
     activeConfigId: null,
     configs: [],
   };
@@ -334,11 +359,12 @@ const loadMultiConfigFromStorage = (): MultiConfigContainer => {
 
 const saveMultiConfigToStorage = (
   configs: SavedConfig[],
-  activeConfigId: string | null
+  activeConfigId: string | null,
+  version: number = 2
 ) => {
   if (typeof window === 'undefined') return;
   const container: MultiConfigContainer = {
-    version: 1,
+    version,
     activeConfigId,
     configs,
   };
@@ -382,7 +408,7 @@ const migrateLegacyConfig = (): MultiConfigContainer => {
       };
       initialData.configs.push(legacyConfig);
       initialData.activeConfigId = newId;
-      saveMultiConfigToStorage(initialData.configs, newId);
+      saveMultiConfigToStorage(initialData.configs, newId, 2);
     }
     localStorage.removeItem(LEGACY_STORAGE_CONFIG_KEY);
     localStorage.removeItem(CONFIG_LOCAL_STORAGE_KEY);
@@ -406,6 +432,29 @@ const ConfigContextProvider = ({
   hashError,
   children,
 }: Props) => {
+  const [hadLegacyConfig] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    const legacy1 = localStorage.getItem(LEGACY_STORAGE_CONFIG_KEY);
+    const legacy2 = localStorage.getItem(CONFIG_LOCAL_STORAGE_KEY);
+    return !!(legacy1 || legacy2);
+  });
+
+  const [loadedVersion] = useState<number>(() => {
+    if (typeof window === 'undefined') return 2;
+    const stored = localStorage.getItem(MULTI_CONFIG_STORAGE_KEY);
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        if (parsed && typeof parsed.version === 'number') {
+          return parsed.version;
+        }
+      } catch (err) {
+        console.warn('Failed to parse loaded version:', err);
+      }
+    }
+    return 1;
+  });
+
   const [multiConfig] = useState<MultiConfigContainer>(() => {
     return migrateLegacyConfig();
   });
@@ -494,6 +543,7 @@ const ConfigContextProvider = ({
   const [showConfig, setShowConfig] = useState<boolean>(true);
   const [showDownloads, setShowDownloads] = useState<boolean>(true);
   const [isGenerating, setIsGenerating] = useState<boolean>(false);
+  const [workerReady, setWorkerReady] = useState<boolean>(false);
 
   // Worker refs
   const ergogenWorkerRef = useRef<Worker | null>(null);
@@ -530,6 +580,37 @@ const ConfigContextProvider = ({
     (event: MessageEvent<ErgogenWorkerResponse>) => {
       const response = event.data;
 
+      // Handle background preview generation requests
+      if (
+        response.requestId &&
+        response.requestId.startsWith('background-preview-')
+      ) {
+        const configId = response.requestId.substring(
+          'background-preview-'.length
+        );
+        if (response.type === 'success' && response.results) {
+          const resultsObj = response.results as Results;
+          const svgContent =
+            resultsObj.outlines?.preview?.svg || resultsObj.demo?.svg;
+          const formattedSvg = formatPreviewSvg(svgContent);
+          if (formattedSvg) {
+            setConfigs((prevConfigs) => {
+              const updated = prevConfigs.map((c) =>
+                c.id === configId ? { ...c, previewSvg: formattedSvg } : c
+              );
+              saveMultiConfigToStorage(updated, activeConfigIdRef.current, 2);
+              return updated;
+            });
+          }
+        } else if (response.type === 'error') {
+          console.warn(
+            `Background generation failed for config ${configId}:`,
+            response.error
+          );
+        }
+        return;
+      }
+
       if (response.type === 'error') {
         console.error('--- Ergogen worker error:', response.error);
         setError(response.error);
@@ -549,6 +630,24 @@ const ConfigContextProvider = ({
         // Set results and trigger STL conversion if needed
         if (response.results) {
           const newResults = response.results as Results;
+
+          // Store preview or demo SVG in the active configuration
+          const svgContent =
+            newResults.outlines?.preview?.svg || newResults.demo?.svg;
+          const formattedSvg = formatPreviewSvg(svgContent);
+          const currentActiveId = activeConfigIdRef.current;
+          if (formattedSvg && currentActiveId) {
+            setConfigs((prevConfigs) => {
+              const updated = prevConfigs.map((c) =>
+                c.id === currentActiveId
+                  ? { ...c, previewSvg: formattedSvg }
+                  : c
+              );
+              saveMultiConfigToStorage(updated, currentActiveId, 2);
+              return updated;
+            });
+          }
+
           let willConvertStl = false;
 
           if (
@@ -626,6 +725,7 @@ const ConfigContextProvider = ({
       ergogenWorkerRef.current = createErgogenWorker();
       if (ergogenWorkerRef.current) {
         ergogenWorkerRef.current.onmessage = handleErgogenWorkerMessage;
+        setWorkerReady(true);
       } else {
         console.warn('Failed to initialize Ergogen worker.');
       }
@@ -644,6 +744,7 @@ const ConfigContextProvider = ({
       if (ergogenWorkerRef.current) {
         ergogenWorkerRef.current.terminate();
         ergogenWorkerRef.current = null;
+        setWorkerReady(false);
       }
       if (jscadWorkerRef.current) {
         jscadWorkerRef.current.terminate();
@@ -1178,6 +1279,7 @@ const ConfigContextProvider = ({
       if (ergogenWorkerRef.current) {
         ergogenWorkerRef.current.terminate();
         ergogenWorkerRef.current = null;
+        setWorkerReady(false);
         console.log('Ergogen worker terminated.');
       }
 
@@ -1185,6 +1287,7 @@ const ConfigContextProvider = ({
       ergogenWorkerRef.current = createErgogenWorker();
       if (ergogenWorkerRef.current) {
         ergogenWorkerRef.current.onmessage = handleErgogenWorkerMessage;
+        setWorkerReady(true);
         console.log('Ergogen worker initialized.');
       } else {
         console.warn('Failed to initialize Ergogen worker.');
@@ -1224,6 +1327,42 @@ const ConfigContextProvider = ({
     showSettings,
     processInput,
   ]);
+
+  // Trigger background preview generation on mount if loadedVersion is 1 or hadLegacyConfig is true
+  useEffect(() => {
+    if (!workerReady) return;
+
+    if (loadedVersion === 1 || hadLegacyConfig) {
+      console.log(
+        'Version 1 or legacy configuration detected on load. Triggering background preview generation for all configs missing a preview SVG...'
+      );
+
+      // Save directly as version 2 to prevent triggering this again next time
+      saveMultiConfigToStorage(
+        configsRef.current,
+        activeConfigIdRef.current,
+        2
+      );
+
+      // Loop through all configurations that don't have a previewSvg and generate them
+      configsRef.current.forEach((cfg) => {
+        if (!cfg.previewSvg) {
+          console.log(
+            `Triggering background preview generation for: ${cfg.name}`
+          );
+          ergogenWorkerRef.current?.postMessage({
+            type: 'generate',
+            inputConfig: cfg.config,
+            requestId: `background-preview-${cfg.id}`,
+            options: {
+              debug: true,
+              svg: true,
+            },
+          });
+        }
+      });
+    }
+  }, [workerReady, loadedVersion, hadLegacyConfig]);
 
   const experiment = useMemo(() => {
     const urlParams = new URLSearchParams(window.location.search);

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -206,6 +206,38 @@ const ExampleName = styled.div`
   text-align: center;
 `;
 
+const ExampleSvgWrapper = styled.div`
+  width: 100%;
+  height: 150px;
+  padding: 8px;
+  box-sizing: border-box;
+  background-color: ${theme.colors.backgroundLighter};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+  }
+`;
+
+const FallbackIconContainer = styled.div`
+  width: 100%;
+  height: 150px;
+  box-sizing: border-box;
+  background-color: ${theme.colors.backgroundLighter};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${theme.colors.textDarker};
+
+  .material-symbols-outlined {
+    font-size: 4rem;
+  }
+`;
+
 // Flatten examples into a single list, excluding the "Empty" one which has a dedicated button
 const allExamples: ConfigOption[] = exampleOptions
   .flatMap((group) => group.options)
@@ -284,6 +316,33 @@ const Welcome = () => {
       setShouldNavigate(true);
     }
   };
+
+  const handleSelectSavedConfig = async (id: string) => {
+    if (configContext) {
+      const cfg = configContext.configs.find((c) => c.id === id);
+      if (cfg) {
+        configContext.selectConfig(id);
+        trackEvent('saved_config_loaded', {
+          config_name: cfg.name,
+          config_id: cfg.id,
+        });
+        await configContext.generateNow(
+          cfg.config,
+          configContext.injectionInput,
+          { pointsonly: false }
+        );
+        setShouldNavigate(true);
+      }
+    }
+  };
+
+  const savedConfigs = configContext?.configs || [];
+  const latestConfigs = [...savedConfigs]
+    .sort(
+      (a, b) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    )
+    .slice(0, 4);
 
   /**
    * Processes footprints (or any injections) with conflict resolution.
@@ -603,6 +662,43 @@ const Welcome = () => {
             </GitHubInputContainer>
           </OptionBox>
         </OptionsContainer>
+
+        {latestConfigs.length > 0 && (
+          <>
+            <h2
+              style={{
+                textAlign: 'center',
+                marginBottom: '2rem',
+                fontSize: theme.fontSizes.h2,
+              }}
+            >
+              Pick up where you left
+            </h2>
+            <ExamplesGrid style={{ marginBottom: '3rem' }}>
+              {latestConfigs.map((cfg) => (
+                <ExampleCard
+                  key={cfg.id}
+                  onClick={() => handleSelectSavedConfig(cfg.id)}
+                  aria-label={`Load ${cfg.name} configuration`}
+                  data-testid={`saved-config-${cfg.name.toLowerCase().replace(/\s+/g, '-')}`}
+                >
+                  {cfg.previewSvg ? (
+                    <ExampleSvgWrapper
+                      dangerouslySetInnerHTML={{ __html: cfg.previewSvg }}
+                    />
+                  ) : (
+                    <FallbackIconContainer>
+                      <span className="material-symbols-outlined">
+                        keyboard_off
+                      </span>
+                    </FallbackIconContainer>
+                  )}
+                  <ExampleName>{cfg.name}</ExampleName>
+                </ExampleCard>
+              ))}
+            </ExamplesGrid>
+          </>
+        )}
 
         <h2
           style={{


### PR DESCRIPTION
# Recent Configurations Preview ("Pick up where you left")

This PR adds a **"Pick up where you left"** section to the welcome page (`/new`) showcasing up to 4 of the user's most recently edited configurations. To support this visually, the multi-config storage system is upgraded to version 2 to store formatted layouts as dark-themed SVG previews directly in `localStorage`. 

## Key Changes

### 1. Persistence & Migration Layer (`ConfigContext.tsx`)
- Upgraded the storage version to `2`.
- Added an optional `previewSvg` field to the `SavedConfig` metadata object.
- Added a `formatPreviewSvg` utility function to clean up, scale, and color SVG previews from Ergogen (forcing `width="284px"` and `height="134px"`, applying dark backgrounds, and recoloring black strokes to `#AAA` to match the UI).
- Automatically triggers background preview generation on mount for all configurations that lack a `previewSvg` if the user is upgrading from version 1 or migrating from legacy configs.
- Intercepts background-preview compilation results (`requestId` starting with `background-preview-`) to save the generated SVG, bypassing the expensive STL/JSCAD generation.
- Automatically saves formatted layout previews when standard generations (user-initiated or auto-generations) complete successfully.

### 2. Welcome Page Section (`Welcome.tsx` & `public/index.html`)
- Displays a new styled row showing the 4 most recently updated layouts.
- Adds `ExampleSvgWrapper` to safely render layout SVGs inline using `dangerouslySetInnerHTML`.
- Displays a centered `keyboard_off` icon from Material Symbols when a layout is empty or fails to compile (fails gracefully, keeping any older SVG without retrying).
- Includes the layout name styled at the bottom of the card, matching the examples.
- Updated the Google Fonts stylesheet link in `public/index.html` to load the `keyboard_off` icon.

### 3. Verification
- Added 3 unit tests in `ConfigContext.test.tsx` verifying:
  - Version 1 upgrade triggers background generation.
  - Background compiles store SVGs and skip STL conversions.
  - Standard compiles successfully store SVGs.
- Ran full formatting, linting, knip, and unit tests (`yarn precommit`), all of which pass successfully.