### PR TITLE
Fix/monaco cursor jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Smooth Monaco Editor Experience
+
+July 06, 2026
+
+![The Monaco editor with an active keyboard layout configuration.](./public/images/changelog/placeholder.png)
+
+Editing relatively large keyboard configurations on a slow CPU or at a sustained speed previously caused the Monaco editor to lag, briefly flash, and reset the cursor to the bottom of the page. This happened because the application executed heavy serialization and synchronous local storage updates on every keystroke, disrupting focus and breaking flow.
+
+To solve this, we redesigned the editor integration to run in uncontrolled mode and debounced context state propagation by 500 milliseconds. Key inputs are captured in real-time in the background without triggering expensive React renders or blocking disk writes during active typing. When focus is lost, or when explicit actions (like downloads or generation) are executed, the system immediately flushes the latest editor contents to keep the workspace in sync without interruptions.
+
+**What changed:**
+
+- **Zero-Lag Typing**: Debounced context updates by 500ms, avoiding blocking localStorage stringification and page re-renders during active typing
+- **Cursor Stability**: Refactored the Monaco integration to prevent cursor position resets and flashing when editing heavy configurations
+- **Focus Blur Auto-Save**: Synchronizes the workspace state immediately when the editor loses focus (e.g. clicking buttons or switching panels)
+- **Realtime Downloads**: Ensured downloading or compiling configurations always uses the exact up-to-the-second code buffer from the editor
+
 ## Multi-Configuration Management System
 
 July 06, 2026

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -346,6 +346,15 @@ The application features a built-in Multi-Configuration Management system allowi
 3. **ZIP Exporter Utilities (`zip.ts`)**:
    - Offers background worker compilation sequences that compiles all configurations concurrently or sequentially and zips them up into a single file with custom folder structures.
 
+## Monaco Editor & Performance Optimization
+
+To prevent editing lag and cursor jumping in the Monaco editor when working with heavy configurations or on slow CPUs:
+
+- **Uncontrolled Editor Component**: The Monaco `Editor` component in `src/molecules/ConfigEditor.tsx` is configured as uncontrolled (using `defaultValue` instead of `value`). This prevents React from forcing value synchronizations on every render.
+- **Debounced Context State Updates**: Keystrokes trigger a debounced context update (500ms delay) using `lodash.debounce`. This avoids triggering heavy React tree re-renders and synchronous `localStorage` disk writes (which stringify all configurations and their SVG previews) during active typing.
+- **Focus Blur Flushing**: Any pending debounced state update is immediately flushed via `debouncedSetConfigInput.flush()` when the editor loses focus (such as when a user clicks the "Download" or "Generate" buttons), ensuring other components have the latest value immediately.
+- **Realtime Context Reference**: The context exposes `getRealtimeConfigInput` and `updateRealtimeConfigInput` to track the synchronous, real-time code buffer value via a React ref. Action handlers (like download and compile generation) prefer this realtime value over the debounced state value to ensure they always operate on the absolute latest changes.
+
 ## Future Tasks
 
 When adding a new future task, always structure them with a unique ID, a brief title, the context, and the task, for example:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ergogen-gui",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A web-based GUI for Ergogen, the ergonomic keyboard layout generator.",
   "license": "MIT",
   "private": false,

--- a/src/Ergogen.tsx
+++ b/src/Ergogen.tsx
@@ -474,7 +474,9 @@ const Ergogen = () => {
    * Triggers a browser download of the current configuration as a 'config.yaml' file.
    */
   const handleDownload = () => {
-    if (configContext.configInput === undefined) {
+    const latestConfig =
+      configContext.getRealtimeConfigInput?.() ?? configContext.configInput;
+    if (latestConfig === undefined) {
       return;
     }
     trackEvent('download_button_clicked', {
@@ -482,7 +484,7 @@ const Ergogen = () => {
       file_name: 'config.yaml',
     });
     const element = document.createElement('a');
-    const file = new Blob([configContext.configInput], { type: 'text/yaml' });
+    const file = new Blob([latestConfig], { type: 'text/yaml' });
     element.href = URL.createObjectURL(file);
     element.download = 'config.yaml';
     document.body.appendChild(element);

--- a/src/context/ConfigContext.test.tsx
+++ b/src/context/ConfigContext.test.tsx
@@ -999,4 +999,34 @@ describe('ConfigContextProvider', () => {
       expect(stored.configs[0].previewSvg).toContain('stroke="#AAA"');
     });
   });
+
+  describe('realtime config input functions', () => {
+    it('should retrieve and update the realtime config input value', () => {
+      let capturedContext: any = null;
+      const TestComponent = () => {
+        capturedContext = useConfigContext();
+        return null;
+      };
+
+      render(
+        <ConfigContextProvider configInput="points: {}">
+          <TestComponent />
+        </ConfigContextProvider>
+      );
+
+      expect(capturedContext.getRealtimeConfigInput()).toBe('points: {}');
+
+      act(() => {
+        capturedContext.updateRealtimeConfigInput('points: { modified: true }');
+      });
+
+      // It should update the realtime value ref
+      expect(capturedContext.getRealtimeConfigInput()).toBe(
+        'points: { modified: true }'
+      );
+
+      // But configInput state should remain the old value (no re-render update to state yet)
+      expect(capturedContext.configInput).toBe('points: {}');
+    });
+  });
 });

--- a/src/context/ConfigContext.tsx
+++ b/src/context/ConfigContext.tsx
@@ -106,6 +106,8 @@ type Props = {
  */
 type ContextProps = {
   configInput: string | undefined;
+  getRealtimeConfigInput: () => string | undefined;
+  updateRealtimeConfigInput: (val: string | undefined) => void;
   setConfigInput: Dispatch<SetStateAction<string | undefined>>;
   configs: SavedConfig[];
   activeConfigId: string | null;
@@ -512,6 +514,20 @@ const ConfigContextProvider = ({
     configInputRef.current = configInputState;
   }, [configInputState]);
 
+  const realtimeConfigInputRef = useRef<string | undefined>(configInputState);
+
+  useEffect(() => {
+    realtimeConfigInputRef.current = configInputState;
+  }, [configInputState]);
+
+  const updateRealtimeConfigInput = useCallback((val: string | undefined) => {
+    realtimeConfigInputRef.current = val;
+  }, []);
+
+  const getRealtimeConfigInput = useCallback(() => {
+    return realtimeConfigInputRef.current;
+  }, []);
+
   const [injectionInput, setInjectionInput] = useLocalStorage<string[][]>(
     'ergogen:injection',
     initialInjectionInput
@@ -831,12 +847,17 @@ const ConfigContextProvider = ({
       injectionInput: string[][] | undefined,
       options: ProcessOptions = { pointsonly: true }
     ) => {
-      if (!textInput) {
+      const targetInput =
+        textInput === undefined || textInput === configInputRef.current
+          ? (realtimeConfigInputRef.current ?? configInputRef.current)
+          : textInput;
+
+      if (!targetInput) {
         return;
       }
-      let inputConfig: string | object = textInput ?? '';
+      let inputConfig: string | object = targetInput;
       const inputInjection: string[][] | undefined = injectionInput;
-      const [, parsedConfig] = parseConfig(textInput ?? '');
+      const [, parsedConfig] = parseConfig(targetInput);
 
       setError(null);
       setDeprecationWarning(null);
@@ -1372,6 +1393,8 @@ const ConfigContextProvider = ({
   const contextValue = useMemo(
     () => ({
       configInput: configInputState,
+      getRealtimeConfigInput,
+      updateRealtimeConfigInput,
       setConfigInput,
       configs,
       activeConfigId,
@@ -1426,6 +1449,8 @@ const ConfigContextProvider = ({
     }),
     [
       configInputState,
+      getRealtimeConfigInput,
+      updateRealtimeConfigInput,
       setConfigInput,
       configs,
       activeConfigId,

--- a/src/molecules/ConfigEditor.tsx
+++ b/src/molecules/ConfigEditor.tsx
@@ -1,5 +1,6 @@
 import { Editor, OnMount } from '@monaco-editor/react';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
+import debounce from 'lodash.debounce';
 import { useConfigContext } from '../context/ConfigContext';
 
 /**
@@ -40,6 +41,7 @@ const ConfigEditor = ({
   'aria-label': ariaLabel,
 }: Props) => {
   const configContext = useConfigContext();
+  const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
 
   // Provide safe defaults when context is null to avoid conditional hooks
   const defaults = {
@@ -49,6 +51,7 @@ const ConfigEditor = ({
     ) => {}) as unknown as React.Dispatch<
       React.SetStateAction<string | undefined>
     >,
+    updateRealtimeConfigInput: (_val: string | undefined) => {},
     injectionInput: undefined as string[][] | undefined,
     generateNow: (async () => {}) as (
       textInput: string | undefined,
@@ -57,8 +60,37 @@ const ConfigEditor = ({
     ) => Promise<void>,
   };
 
-  const { configInput, setConfigInput, injectionInput, generateNow } =
-    configContext ?? defaults;
+  const {
+    configInput,
+    updateRealtimeConfigInput,
+    setConfigInput,
+    injectionInput,
+    generateNow,
+  } = configContext ?? defaults;
+
+  // Create a debounced setConfigInput to avoid updating context on every keystroke
+  const debouncedSetConfigInput = useRef(
+    debounce((val: string) => {
+      setConfigInput(val);
+    }, 500)
+  ).current;
+
+  // Cleanup debounce on unmount
+  useEffect(() => {
+    return () => {
+      debouncedSetConfigInput.cancel();
+    };
+  }, [debouncedSetConfigInput]);
+
+  // Sync editor value with context configInput (only when changed from outside)
+  useEffect(() => {
+    if (editorRef.current) {
+      const currentVal = editorRef.current.getValue();
+      if (configInput !== undefined && configInput !== currentVal) {
+        editorRef.current.setValue(configInput);
+      }
+    }
+  }, [configInput]);
 
   /**
    * Handles changes in the editor's content.
@@ -66,22 +98,35 @@ const ConfigEditor = ({
    * @param {string | undefined} textInput - The new text content from the editor.
    */
   const handleChange = useCallback(
-    async (textInput: string | undefined) => {
-      if (!textInput) return null;
+    (textInput: string | undefined) => {
+      if (textInput === undefined) return;
 
-      setConfigInput(textInput);
+      // Sync the realtime value ref immediately (without triggering re-renders)
+      updateRealtimeConfigInput(textInput);
+
+      // Debounce the state/localStorage update
+      debouncedSetConfigInput(textInput);
     },
-    [setConfigInput]
+    [debouncedSetConfigInput, updateRealtimeConfigInput]
   );
 
   const handleEditorDidMount: OnMount = (editor, monaco) => {
+    editorRef.current = editor;
+
+    // Flush/save changes immediately on blur to ensure download/generate buttons have the latest value
+    editor.onDidBlurEditorText(() => {
+      debouncedSetConfigInput.flush();
+    });
+
     editor.addAction({
       id: 'generate-config',
       label: 'Generate',
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
       run: () => {
         const currentConfig = editor.getValue();
-        // Also update the context state so the UI is in sync
+        // Cancel pending debounces and apply immediately
+        debouncedSetConfigInput.cancel();
+        updateRealtimeConfigInput(currentConfig);
         setConfigInput(currentConfig);
         generateNow(currentConfig, injectionInput, { pointsonly: false });
       },
@@ -98,9 +143,8 @@ const ConfigEditor = ({
         language="yaml"
         onChange={handleChange}
         onMount={handleEditorDidMount}
-        value={configInput}
-        theme={'ergogen-theme'}
         defaultValue={configInput}
+        theme={'ergogen-theme'}
         options={options || undefined}
       />
     </div>

--- a/src/molecules/ConfigEditor.tsx
+++ b/src/molecules/ConfigEditor.tsx
@@ -58,6 +58,7 @@ const ConfigEditor = ({
       injectionInput: string[][] | undefined,
       options?: { pointsonly: boolean }
     ) => Promise<void>,
+    activeConfigId: null as string | null,
   };
 
   const {
@@ -66,6 +67,7 @@ const ConfigEditor = ({
     setConfigInput,
     injectionInput,
     generateNow,
+    activeConfigId,
   } = configContext ?? defaults;
 
   // Create a debounced setConfigInput to avoid updating context on every keystroke
@@ -85,6 +87,11 @@ const ConfigEditor = ({
   // Sync editor value with context configInput (only when changed from outside)
   useEffect(() => {
     if (editorRef.current) {
+      // If the editor currently has focus, the changes came from user typing.
+      // Do not overwrite the editor as that resets the cursor position.
+      if (editorRef.current.hasTextFocus()) {
+        return;
+      }
       const currentVal = editorRef.current.getValue();
       if (configInput !== undefined && configInput !== currentVal) {
         editorRef.current.setValue(configInput);
@@ -138,6 +145,7 @@ const ConfigEditor = ({
   return (
     <div className={className} data-testid={dataTestId} aria-label={ariaLabel}>
       <Editor
+        key={activeConfigId || 'preview'}
         height="100%"
         defaultLanguage="yaml"
         language="yaml"


### PR DESCRIPTION
# Fix Monaco editor typing lag and cursor jumping

## Problem
Editing relatively large configurations on a slow CPU or at a sustained speed caused the Monaco editor to lag, briefly flash, and reset the cursor to the bottom or beginning of the file. 

This occurred because the application executed heavy serialization and synchronous local storage updates on every keystroke, blocking the main thread. When the React state updates finally caught up, Monaco received an outdated `value` prop, detected a mismatch (`value !== model.getValue()`), and called `setValue()`, resetting the cursor position and losing undo history.

## Solution

To resolve this issue, the editor integration has been redesigned to use an uncontrolled approach combined with debounced state synchronization:

1. **Uncontrolled Editor Component**: Replaced the controlled `value` prop on the Monaco `Editor` with `defaultValue`. This prevents React from forcing synchronous value updates on every render cycle.
2. **Debounced Context State Updates**: Debounced updating the React context state (and by extension, the synchronous writes to local storage) by 500ms using `lodash.debounce`. This eliminates rendering and disk write overhead during active typing.
3. **Focus Protection**: Updated the synchronization `useEffect` to return early if the editor currently has focus (`editorRef.current.hasTextFocus()`). This guarantees that React never overwrites the editor's value while a user is actively typing.
4. **Re-keying on Config Switch**: Passed `key={activeConfigId}` to the editor so it cleanly unmounts and remounts when changing files in the sidebar, resetting the editor state (such as undo history) cleanly.
5. **Focus Blur Auto-Save**: Added an `onDidBlurEditorText` listener to immediately flush the debounced updates when the editor loses focus (e.g. when clicking a button or changing panels).
6. **Real-time Context Reference**: Added a synchronous React ref in the context to track the absolute latest value of the configuration. Modified the generation pipeline and configuration download handlers to prefer this real-time ref value over the debounced state value.

Addresses and closes #99 