### PR TITLE
Add sidebar version displays and custom build indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Sidebar Version Displays & DEV Build Indicators
+
+July 07, 2026
+
+![A view of the sidebar showing the GUI version button and the custom Ergogen version badge.](./public/images/changelog/placeholder.png)
+
+Understanding which version of the GUI and Ergogen was currently running in the workspace was previously hidden from the interface. It was also difficult to tell if the application was compiling using a custom repository fork, branch reference, tag, or commit hash.
+
+To improve transparency, we have added version buttons in the sidebar footer and introduced custom dev badges. The sidebar footer now displays two separate buttons: one linking to the GUI codebase (showing its package version, e.g. `0.6.3`) and another linking to the active Ergogen source code. If you are building using a custom Ergogen repository or tag, the version text appears green and shows a vertical `DEV` badge on the button. We also added a green superscript beaker chip next to the logo, which opens an explanation modal with details and links when hovered or tapped.
+
+**What changed:**
+
+- **GUI & Ergogen Footer Buttons**: Added two-line version buttons in the sidebar footer linking to their respective GitHub codebases
+- **Custom build indicators**: Displays custom repository tags, branches, or hashes in green with a vertical `DEV` badge on the Ergogen button
+- **Superscript Beaker Chip**: Shows a superscript beaker chip next to the app logo in both the Header and Sidebar when a custom built version is active
+- **Interactive Explanatory Modal**: Hovering or tapping the beaker chip opens a popup modal with details about the custom source code and a link
+- **Automated commit truncation**: Detects 40-character commit hashes, truncating them to 7 characters (e.g., `fb2509f`) and linking directly to `/commit/` URLs
+- **Cleaned up headers**: Removed the old plain version label next to the logo to declutter the workspace header and sidebar logo sections
+
 ## Advanced Interaction Analytics & Cleanup
 
 July 06, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ July 07, 2026
 
 Understanding which version of the GUI and Ergogen was currently running in the workspace was previously hidden from the interface. It was also difficult to tell if the application was compiling using a custom repository fork, branch reference, tag, or commit hash.
 
-To improve transparency, we have added version buttons in the sidebar footer and introduced custom dev badges. The sidebar footer now displays two separate buttons: one linking to the GUI codebase (showing its package version, e.g. `0.6.3`) and another linking to the active Ergogen source code. If you are building using a custom Ergogen repository or tag, the version text appears green and shows a vertical `DEV` badge on the button. We also added a green superscript beaker chip next to the logo, which opens an explanation modal with details and links when hovered or tapped.
+To improve transparency, we have added version buttons in the sidebar footer and introduced custom dev badges. The sidebar footer now displays two separate buttons: one linking to the GUI codebase (showing its package version, e.g., `0.6.4`) and another linking to the active Ergogen source code. If you are building using a custom Ergogen repository or tag, the version text appears green and shows a vertical `DEV` badge on the button. We also added a green superscript beaker chip next to the logo, which opens an explanation modal with details and links when hovered or tapped.
 
 **What changed:**
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -328,6 +328,26 @@ To allow developers and CI to override the default Ergogen version using the `ER
    - Executes after dependencies are successfully installed.
    - If `packages.json.bak` exists, it restores the original `package.json` and deletes the backup file, ensuring that the workspace remains clean and no modified `package.json` is committed.
 
+## Version Information & Custom Build Indicators
+
+To improve transparency and debuggability for users running custom repositories, branches, tags, or commit hashes of Ergogen, the application displays version information directly in the sidebar footer and highlights custom builds using dedicated badges:
+
+- **GUI Version Button**: Displays the GitHub logo alongside "GUI" and the local `package.json` version (e.g., `0.6.3`). Clicking it links directly to the GUI codebase on GitHub.
+- **Ergogen Version Button**: Displays the GitHub logo alongside "Ergogen" and the currently built Ergogen version.
+  - **Standard Releases**: Shows the standard version number (e.g., `4.2.1`) in standard gray.
+  - **Custom Builds**: If built using a custom repository or reference (detected via `isCustom`), the version text is colored in green (`theme.colors.accent`) and a vertical `DEV` badge is shown on the right-hand edge of the button.
+  - **Commit Hashes**: Full 40-character commit hashes are automatically truncated to 7 characters (e.g., `fb2509f`) and link directly to `/commit/` on GitHub instead of `/tree/`.
+  - **Other References**: Shorter labels (such as tags like `v4.3.0` or branch names like `develop`) are kept intact and link to `/tree/` on GitHub.
+
+### Custom DEV Chip & Explanation Modal
+
+When the built Ergogen version is custom (`isCustom` is true), a green superscript DEV chip (`<DevChip>`) is displayed next to the app name in both the Header and Sidebar.
+
+- **Icon and Badge**: Contains a beaker (`science`) icon and `DEV` text.
+- **Hover/Tap Popover**: Hovering (desktop) or tapping (mobile) on the chip triggers a floating explanation popover card.
+- **Close Delay**: Incorporates a 250ms mouse-leave transition delay to allow the user's cursor to navigate into the popover and click the repository link without closing the card prematurely.
+- **Global Click Close**: Sets up global window click listeners to automatically close the popover on touch screens or outer clicks.
+
 ## Multi-Configuration Management
 
 The application features a built-in Multi-Configuration Management system allowing users to work on multiple YAML/JSON configurations, switch between them instantly, search their lists, rename, duplicate, and delete configurations.
@@ -492,3 +512,9 @@ Proposed Fix: I will break down the runGeneration function into several smaller,
 **Context:** The Google Tag (`gtag.js`) script tag is currently hardcoded in `public/index.html`. In environments where `REACT_APP_GTAG_ID` is not defined (such as local development or forks), the browser still attempts to download the library from Google with the literal string `%REACT_APP_GTAG_ID%`, causing a console network error.
 
 **Task:** Refactor Google Tag initialization. Remove the script tags from `public/index.html` and implement dynamic script injection inside `src/utils/analytics.ts`. The script should only inject standard DOM script elements if the `REACT_APP_GTAG_ID` is present, valid, and not the CRA replacement placeholder.
+
+### [TASK-015] Componentize and Abstract Version Button Layouts
+
+**Context:** The GUI and Ergogen version buttons inside the sidebar footer are currently built using locally defined styled-components inside `SideNavigation.tsx`. If other sidebars or footers are added in the future, these styling structures might need to be duplicated.
+
+**Task:** Refactor the double-line version buttons and the vertical DEV badges into a reusable atomic/molecular component (e.g. `src/molecules/GithubVersionButton.tsx`) to keep `SideNavigation.tsx` focused and improve design system consistency.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ergogen-gui",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "A web-based GUI for Ergogen, the ergonomic keyboard layout generator.",
   "license": "MIT",
   "private": false,

--- a/src/atoms/DevChip.test.tsx
+++ b/src/atoms/DevChip.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { DevChip } from './DevChip';
+import { VersionInfo } from '../utils/version';
+
+describe('DevChip', () => {
+  const mockVersionInfo: VersionInfo = {
+    label: 'ceoloide/ergogen#v4.3.0',
+    url: 'https://github.com/ceoloide/ergogen/tree/v4.3.0',
+    displayText: 'v4.3.0',
+    isCustom: true,
+    isTag: true,
+    isHash: false,
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders the DEV chip with beaker icon', () => {
+    // Arrange & Act
+    render(
+      <DevChip versionInfo={mockVersionInfo} data-testid="test-dev-chip" />
+    );
+
+    // Assert
+    const badge = screen.getByTestId('test-dev-chip-badge');
+    expect(badge).toBeInTheDocument();
+    expect(screen.getByText('science')).toBeInTheDocument();
+    expect(screen.queryByText('DEV')).not.toBeInTheDocument();
+  });
+
+  it('displays the popover modal on hover and closes on mouse leave with delay', () => {
+    // Arrange
+    render(
+      <DevChip versionInfo={mockVersionInfo} data-testid="test-dev-chip" />
+    );
+    const wrapper = screen.getByTestId('test-dev-chip');
+
+    // Act (Hover in)
+    fireEvent.mouseEnter(wrapper);
+
+    // Assert popover is visible
+    expect(screen.getByTestId('test-dev-chip-popover')).toBeInTheDocument();
+    expect(screen.getByText('Custom Ergogen Version')).toBeInTheDocument();
+    expect(
+      screen.getByText(/running a custom version of Ergogen/)
+    ).toBeInTheDocument();
+
+    const link = screen.getByTestId('test-dev-chip-link');
+    expect(link).toHaveAttribute('href', mockVersionInfo.url);
+    expect(screen.getByText(mockVersionInfo.label)).toBeInTheDocument();
+
+    // Act (Mouse leave wrapper)
+    fireEvent.mouseLeave(wrapper);
+
+    // Assert popover is still visible immediately (due to delay)
+    expect(screen.getByTestId('test-dev-chip-popover')).toBeInTheDocument();
+
+    // Act (Advance timers to trigger close)
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    // Assert popover is closed
+    expect(
+      screen.queryByTestId('test-dev-chip-popover')
+    ).not.toBeInTheDocument();
+  });
+
+  it('toggles the popover modal on click', () => {
+    // Arrange
+    render(
+      <DevChip versionInfo={mockVersionInfo} data-testid="test-dev-chip" />
+    );
+    const badge = screen.getByTestId('test-dev-chip-badge');
+
+    // Act (Click to open)
+    fireEvent.click(badge);
+
+    // Assert popover is open
+    expect(screen.getByTestId('test-dev-chip-popover')).toBeInTheDocument();
+
+    // Act (Click to close)
+    fireEvent.click(badge);
+
+    // Assert popover is closed
+    expect(
+      screen.queryByTestId('test-dev-chip-popover')
+    ).not.toBeInTheDocument();
+  });
+
+  it('closes popover on global click', () => {
+    // Arrange
+    render(
+      <div>
+        <div data-testid="outside-element">Outside</div>
+        <DevChip versionInfo={mockVersionInfo} data-testid="test-dev-chip" />
+      </div>
+    );
+    const badge = screen.getByTestId('test-dev-chip-badge');
+
+    // Act (Click badge to open)
+    fireEvent.click(badge);
+    expect(screen.getByTestId('test-dev-chip-popover')).toBeInTheDocument();
+
+    // Act (Click outside)
+    fireEvent.click(screen.getByTestId('outside-element'));
+
+    // Assert popover closes
+    expect(
+      screen.queryByTestId('test-dev-chip-popover')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/atoms/DevChip.tsx
+++ b/src/atoms/DevChip.tsx
@@ -1,0 +1,195 @@
+import React, { useState, useRef, useEffect } from 'react';
+import styled from 'styled-components';
+import { theme } from '../theme/theme';
+import { VersionInfo } from '../utils/version';
+
+interface DevChipProps {
+  versionInfo: VersionInfo;
+  'data-testid'?: string;
+}
+
+export const DevChip: React.FC<DevChipProps> = ({
+  versionInfo,
+  'data-testid': dataTestId,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleMouseEnter = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsOpen(true);
+  };
+
+  const handleMouseLeave = () => {
+    timeoutRef.current = setTimeout(() => {
+      setIsOpen(false);
+    }, 250);
+  };
+
+  const handlePopoverMouseEnter = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+  };
+
+  const handlePopoverMouseLeave = () => {
+    timeoutRef.current = setTimeout(() => {
+      setIsOpen(false);
+    }, 250);
+  };
+
+  const handleChipClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsOpen((prev) => !prev);
+  };
+
+  // Close popover when clicking anywhere else
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleGlobalClick = () => {
+      setIsOpen(false);
+    };
+
+    window.addEventListener('click', handleGlobalClick);
+    return () => {
+      window.removeEventListener('click', handleGlobalClick);
+    };
+  }, [isOpen]);
+
+  // Clean up timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <ChipWrapper
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      data-testid={dataTestId}
+    >
+      <ChipElement
+        onClick={handleChipClick}
+        data-testid={dataTestId && `${dataTestId}-badge`}
+        aria-label="Custom Ergogen version indicator"
+      >
+        <span className="material-symbols-outlined">science</span>
+      </ChipElement>
+
+      {isOpen && (
+        <PopoverCard
+          onMouseEnter={handlePopoverMouseEnter}
+          onMouseLeave={handlePopoverMouseLeave}
+          onClick={(e) => e.stopPropagation()}
+          data-testid={dataTestId && `${dataTestId}-popover`}
+        >
+          <PopoverTitle>Custom Ergogen Version</PopoverTitle>
+          <PopoverText>
+            This website is running a custom version of Ergogen for development
+            and preview purposes.
+          </PopoverText>
+          <VersionLink
+            href={versionInfo.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid={dataTestId && `${dataTestId}-link`}
+          >
+            <span>{versionInfo.label}</span>
+            <span className="material-symbols-outlined open-icon">
+              open_in_new
+            </span>
+          </VersionLink>
+        </PopoverCard>
+      )}
+    </ChipWrapper>
+  );
+};
+
+const ChipWrapper = styled.span`
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  transform: translateY(-5px);
+`;
+
+const ChipElement = styled.span`
+  background-color: ${theme.colors.accent};
+  color: ${theme.colors.white};
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  margin-left: 4px;
+  width: 16px;
+  height: 16px;
+  line-height: 1;
+
+  .material-symbols-outlined {
+    font-size: 11px !important;
+  }
+
+  &:hover {
+    background-color: ${theme.colors.accentDark};
+  }
+`;
+
+const PopoverCard = styled.div`
+  position: absolute;
+  top: 100%;
+  left: 4px;
+  margin-top: 6px;
+  background-color: ${theme.colors.backgroundLight};
+  border: 1px solid ${theme.colors.border};
+  border-radius: 6px;
+  padding: 10px 12px;
+  width: 240px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  cursor: default;
+  text-align: left;
+`;
+
+const PopoverTitle = styled.div`
+  font-size: 12px;
+  font-weight: ${theme.fontWeights.semiBold};
+  color: ${theme.colors.white};
+`;
+
+const PopoverText = styled.div`
+  font-size: 11px;
+  color: ${theme.colors.textDark};
+  line-height: 1.4;
+`;
+
+const VersionLink = styled.a`
+  font-size: 11px;
+  color: ${theme.colors.accent};
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 2px;
+  font-weight: ${theme.fontWeights.semiBold};
+  align-self: flex-start;
+  word-break: break-all;
+
+  .open-icon {
+    font-size: 11px !important;
+  }
+
+  &:hover {
+    color: ${theme.colors.accentDark};
+    text-decoration: underline;
+  }
+`;

--- a/src/atoms/Header.tsx
+++ b/src/atoms/Header.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { useConfigContext } from '../context/ConfigContext';
 import { getErgogenVersionInfo } from '../utils/version';
+import { DevChip } from './DevChip';
 import { theme } from '../theme/theme';
 import { createZip } from '../utils/zip';
 import { createShareableUri } from '../utils/share';
@@ -21,6 +22,8 @@ const HeaderContainer = styled.header`
   padding: 0 1rem;
   background-color: ${theme.colors.background};
   flex-shrink: 0;
+  position: relative;
+  z-index: 100;
 
   @media (max-width: 639px) {
     padding: 0 0.5rem;
@@ -65,7 +68,9 @@ const AppName = styled.div`
   font-size: ${theme.fontSizes.base};
   font-weight: ${theme.fontWeights.semiBold};
   color: ${theme.colors.white};
-  @media (max-width: 420px) {
+  display: flex;
+  align-items: center;
+  @media (max-width: 639px) {
     display: none;
   }
 `;
@@ -73,15 +78,6 @@ const AppName = styled.div`
 /**
  * A styled anchor tag for displaying the version number.
  */
-const VersionText = styled.a`
-  font-size: ${theme.fontSizes.sm};
-  color: ${theme.colors.accent};
-  text-decoration: none;
-  align-items: center;
-  @media (max-width: 767px) {
-    display: none;
-  }
-`;
 
 /**
  * A styled button with an outline style, typically for icons.
@@ -133,7 +129,7 @@ const AccentIconButton = styled(OutlineIconButton)`
 `;
 
 const NewButtonText = styled.span`
-  @media (max-width: 375px) {
+  @media (max-width: 510px) {
     display: none;
   }
 `;
@@ -345,16 +341,15 @@ const Header = (): JSX.Element => {
                 alt="Ergogen logo"
               />
             </LogoButton>
-            <AppName>Ergogen</AppName>
-            <VersionText
-              href={versionInfo.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={`View Ergogen ${versionInfo.label} on GitHub`}
-              data-testid="version-link"
-            >
-              {versionInfo.label}
-            </VersionText>
+            <AppName>
+              Ergogen
+              {versionInfo.isCustom && (
+                <DevChip
+                  versionInfo={versionInfo}
+                  data-testid="header-dev-chip"
+                />
+              )}
+            </AppName>
           </ErgogenLogo>
           {activeConfigName && (
             <>
@@ -594,6 +589,9 @@ const ConfigDivider = styled.span`
   font-size: ${theme.fontSizes.sm};
   font-weight: ${theme.fontWeights.semiBold};
   user-select: none;
+  @media (max-width: 639px) {
+    display: none;
+  }
 `;
 
 const ConfigNameText = styled.span`

--- a/src/molecules/SideNavigation.test.tsx
+++ b/src/molecules/SideNavigation.test.tsx
@@ -213,4 +213,46 @@ describe('SideNavigation', () => {
     expect(screen.queryByLabelText('Rename input')).not.toBeInTheDocument();
     expect(screen.getByText('Keyboard Alpha')).toBeInTheDocument();
   });
+
+  it('renders GUI and Ergogen version buttons in the footer', () => {
+    renderComponent();
+
+    // Assert GUI button and version
+    const guiBtn = screen.getByTestId('side-nav-gui-version-button');
+    expect(guiBtn).toBeInTheDocument();
+    expect(screen.getByText('GUI')).toBeInTheDocument();
+    expect(screen.getByText('0.6.3')).toBeInTheDocument();
+
+    // Assert Ergogen button and version
+    const ergogenBtn = screen.getByTestId('side-nav-ergogen-version-button');
+    expect(ergogenBtn).toBeInTheDocument();
+    expect(screen.getAllByText('Ergogen').length).toBe(2);
+  });
+
+  describe('with custom Ergogen version', () => {
+    const originalEnv = process.env.REACT_APP_ERGOGEN_VERSION;
+
+    beforeEach(() => {
+      process.env.REACT_APP_ERGOGEN_VERSION = 'github:ceoloide/ergogen#v4.3.0';
+    });
+
+    afterEach(() => {
+      process.env.REACT_APP_ERGOGEN_VERSION = originalEnv;
+    });
+
+    it('renders the custom version green and displays the DEV marker and DEV chip', () => {
+      renderComponent();
+
+      // Assert DEV chip exists next to app name
+      expect(screen.getByTestId('sidebar-dev-chip-badge')).toBeInTheDocument();
+
+      // Assert Ergogen button has custom version and DEV badge
+      const ergogenBtn = screen.getByTestId('side-nav-ergogen-version-button');
+      expect(ergogenBtn).toBeInTheDocument();
+      expect(screen.getByText('v4.3.0')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('side-nav-ergogen-dev-badge')
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/molecules/SideNavigation.tsx
+++ b/src/molecules/SideNavigation.tsx
@@ -3,6 +3,8 @@ import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { theme } from '../theme/theme';
 import { getErgogenVersionInfo } from '../utils/version';
+import { DevChip } from '../atoms/DevChip';
+import guiPkg from '../../package.json';
 import DiscordIcon from '../atoms/DiscordIcon';
 import GithubIcon from '../atoms/GithubIcon';
 import { useConfigContext } from '../context/ConfigContext';
@@ -35,6 +37,7 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
 
   const configContext = useConfigContext();
   const navigate = useNavigate();
+  const guiVersion = guiPkg.version;
 
   const {
     configs,
@@ -303,17 +306,15 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
                 alt="Ergogen logo"
               />
             </LogoButton>
-            <AppName onClick={onClose}>Ergogen</AppName>
-            <VersionText
-              href={versionInfo.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={onClose}
-              aria-label={`View Ergogen ${versionInfo.label} on GitHub`}
-              data-testid="side-nav-version-link"
-            >
-              {versionInfo.label}
-            </VersionText>
+            <AppName onClick={onClose}>
+              Ergogen
+              {versionInfo.isCustom && (
+                <DevChip
+                  versionInfo={versionInfo}
+                  data-testid="sidebar-dev-chip"
+                />
+              )}
+            </AppName>
           </LogoSection>
           <CloseButton
             onClick={onClose}
@@ -482,19 +483,44 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
             >
               <DiscordIcon />
             </OutlineButton>
-            <OutlineButton
+            <VersionButton
               onClick={() => {
                 window.open(
-                  'https://github.com/ergogen',
+                  'https://github.com/ceoloide/ergogen-gui',
                   '_blank',
                   'noopener,noreferrer'
                 );
               }}
-              aria-label="View the GitHub repositories"
-              data-testid="side-nav-github-button"
+              aria-label={`View Ergogen GUI ${guiVersion} on GitHub`}
+              data-testid="side-nav-gui-version-button"
             >
               <GithubIcon />
-            </OutlineButton>
+              <ButtonContent>
+                <ButtonLabel>GUI</ButtonLabel>
+                <ButtonVersionText>{guiVersion}</ButtonVersionText>
+              </ButtonContent>
+            </VersionButton>
+            <VersionButton
+              onClick={() => {
+                window.open(versionInfo.url, '_blank', 'noopener,noreferrer');
+              }}
+              $hasDevBadge={versionInfo.isCustom}
+              aria-label={`View Ergogen ${versionInfo.displayText} on GitHub`}
+              data-testid="side-nav-ergogen-version-button"
+            >
+              <GithubIcon />
+              <ButtonContent>
+                <ButtonLabel>Ergogen</ButtonLabel>
+                <ButtonVersionText $isCustom={versionInfo.isCustom}>
+                  {versionInfo.displayText}
+                </ButtonVersionText>
+              </ButtonContent>
+              {versionInfo.isCustom && (
+                <DevBadge data-testid="side-nav-ergogen-dev-badge">
+                  <DevBadgeText>DEV</DevBadgeText>
+                </DevBadge>
+              )}
+            </VersionButton>
           </ButtonGroup>
         </Footer>
       </Panel>
@@ -552,6 +578,8 @@ const Header = styled.div`
   padding: 0 1rem;
   height: 3em;
   flex-shrink: 0;
+  position: relative;
+  z-index: 10;
 `;
 
 const LogoSection = styled.div`
@@ -581,12 +609,7 @@ const AppName = styled.div`
   font-weight: ${theme.fontWeights.semiBold};
   color: ${theme.colors.white};
   cursor: pointer;
-`;
-
-const VersionText = styled.a`
-  font-size: ${theme.fontSizes.sm};
-  color: ${theme.colors.accent};
-  text-decoration: none;
+  display: flex;
   align-items: center;
 `;
 
@@ -909,8 +932,7 @@ const EmptyState = styled.div`
 `;
 
 const Footer = styled.div`
-  padding: 0 1rem;
-  height: 3em;
+  padding: 8px 1rem;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -923,6 +945,86 @@ const ButtonGroup = styled.div`
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+  width: 100%;
+`;
+
+const VersionButton = styled.button<{ $hasDevBadge?: boolean }>`
+  background-color: transparent;
+  transition:
+    color 0.15s ease-in-out,
+    background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out,
+    box-shadow 0.15s ease-in-out;
+  border: 1px solid ${theme.colors.border};
+  border-radius: 6px;
+  color: ${theme.colors.white};
+  display: flex;
+  align-items: center;
+  padding: 8px ${(props) => (props.$hasDevBadge ? '22px' : '10px')} 8px 10px;
+  text-decoration: none;
+  cursor: pointer;
+  height: 34px;
+  position: relative;
+  flex: 0 0 auto;
+  gap: 6px;
+
+  svg {
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+  }
+
+  &:hover {
+    background-color: ${theme.colors.buttonHover};
+  }
+`;
+
+const ButtonContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  line-height: 1.1;
+  min-width: 0;
+`;
+
+const ButtonLabel = styled.span`
+  font-size: 10px;
+  font-weight: ${theme.fontWeights.bold};
+  color: ${theme.colors.white};
+  white-space: nowrap;
+`;
+
+const ButtonVersionText = styled.span<{ $isCustom?: boolean }>`
+  font-size: 8px;
+  color: ${(props) =>
+    props.$isCustom ? theme.colors.accent : theme.colors.textDark};
+  white-space: nowrap;
+`;
+
+const DevBadge = styled.div`
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 16px;
+  background-color: ${theme.colors.backgroundLighter};
+  border-left: 1px solid ${theme.colors.border};
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+`;
+
+const DevBadgeText = styled.span`
+  font-size: 8px;
+  font-weight: ${theme.fontWeights.bold};
+  color: ${theme.colors.accent};
+  transform: rotate(-90deg);
+  white-space: nowrap;
+  line-height: 1;
 `;
 
 const OutlineButton = styled.button`

--- a/src/utils/version.test.ts
+++ b/src/utils/version.test.ts
@@ -2,13 +2,18 @@ import { getErgogenVersionInfo } from './version';
 import ergogenPkg from 'ergogen/package.json';
 
 describe('getErgogenVersionInfo', () => {
-  const defaultVersion = `v${ergogenPkg.version}`;
+  const defaultVersion = ergogenPkg.version;
+  const defaultVersionLabel = `v${defaultVersion}`;
   const defaultUrl = 'https://github.com/ergogen/ergogen';
 
   it('returns default version when no version is provided', () => {
     expect(getErgogenVersionInfo()).toEqual({
-      label: defaultVersion,
+      label: defaultVersionLabel,
       url: defaultUrl,
+      displayText: defaultVersion,
+      isCustom: false,
+      isHash: false,
+      isTag: false,
     });
   });
 
@@ -16,6 +21,10 @@ describe('getErgogenVersionInfo', () => {
     expect(getErgogenVersionInfo('ergogen/ergogen')).toEqual({
       label: 'latest',
       url: 'https://github.com/ergogen/ergogen',
+      displayText: defaultVersion,
+      isCustom: false,
+      isHash: false,
+      isTag: false,
     });
   });
 
@@ -23,6 +32,10 @@ describe('getErgogenVersionInfo', () => {
     expect(getErgogenVersionInfo('ergogen/ergogen#develop')).toEqual({
       label: 'develop',
       url: 'https://github.com/ergogen/ergogen/tree/develop',
+      displayText: 'develop',
+      isCustom: true,
+      isHash: false,
+      isTag: true,
     });
   });
 
@@ -30,6 +43,10 @@ describe('getErgogenVersionInfo', () => {
     expect(getErgogenVersionInfo('ceoloide/ergogen')).toEqual({
       label: 'ceoloide/ergogen',
       url: 'https://github.com/ceoloide/ergogen',
+      displayText: defaultVersion,
+      isCustom: true,
+      isHash: false,
+      isTag: false,
     });
   });
 
@@ -37,6 +54,10 @@ describe('getErgogenVersionInfo', () => {
     expect(getErgogenVersionInfo('ceoloide/ergogen#v4.3.0')).toEqual({
       label: 'ceoloide/ergogen#v4.3.0',
       url: 'https://github.com/ceoloide/ergogen/tree/v4.3.0',
+      displayText: 'v4.3.0',
+      isCustom: true,
+      isHash: false,
+      isTag: true,
     });
   });
 
@@ -44,6 +65,10 @@ describe('getErgogenVersionInfo', () => {
     expect(getErgogenVersionInfo('github:ceoloide/ergogen#develop')).toEqual({
       label: 'ceoloide/ergogen#develop',
       url: 'https://github.com/ceoloide/ergogen/tree/develop',
+      displayText: 'develop',
+      isCustom: true,
+      isHash: false,
+      isTag: true,
     });
   });
 
@@ -51,6 +76,24 @@ describe('getErgogenVersionInfo', () => {
     expect(getErgogenVersionInfo('ergogen@4.2.0')).toEqual({
       label: 'ergogen@4.2.0',
       url: 'https://github.com/ergogen/ergogen/releases/tag/v4.2.0',
+      displayText: '4.2.0',
+      isCustom: true,
+      isHash: false,
+      isTag: true,
+    });
+  });
+
+  it('handles 40-character commit hashes correctly', () => {
+    const fullHash = 'fb2509f8e404b9015c7e3ebbd6931754020a2e0a';
+    expect(
+      getErgogenVersionInfo(`github:ceoloide/ergogen#${fullHash}`)
+    ).toEqual({
+      label: `ceoloide/ergogen#${fullHash}`,
+      url: `https://github.com/ceoloide/ergogen/commit/${fullHash}`,
+      displayText: 'fb2509f',
+      isCustom: true,
+      isHash: true,
+      isTag: false,
     });
   });
 });

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,18 +1,23 @@
 import ergogenPkg from 'ergogen/package.json';
 
-interface VersionInfo {
+export interface VersionInfo {
   label: string;
   url: string;
+  displayText: string;
+  isCustom: boolean;
+  isHash?: boolean;
+  isTag?: boolean;
 }
 
 /**
  * Gets the Ergogen version label and GitHub URL for display in the UI.
  *
  * @param version The version string from the environment variable.
- * @returns An object containing the formatted label and the corresponding URL.
+ * @returns An object containing the formatted label, URL, and metadata.
  */
 export const getErgogenVersionInfo = (version?: string): VersionInfo => {
-  const defaultVersion = `v${ergogenPkg.version}`;
+  const defaultVersionLabel = `v${ergogenPkg.version}`;
+  const defaultVersion = ergogenPkg.version;
 
   const repoStr =
     typeof ergogenPkg.repository === 'string'
@@ -28,16 +33,29 @@ export const getErgogenVersionInfo = (version?: string): VersionInfo => {
     : repoStr.replace(/^git\+/, '').replace(/\.git$/, '');
 
   if (!version) {
-    return { label: defaultVersion, url: defaultUrl };
+    return {
+      label: defaultVersionLabel,
+      url: defaultUrl,
+      displayText: defaultVersion,
+      isCustom: false,
+      isHash: false,
+      isTag: false,
+    };
   }
 
   // Handle NPM version (e.g., ergogen@4.2.0)
   if (version.includes('@')) {
+    const parts = version.split('@');
+    const verPart = parts[1] || version;
     return {
       label: version,
       url: version.startsWith('ergogen@')
-        ? `${defaultUrl}/releases/tag/v${version.split('@')[1]}`
-        : `https://www.npmjs.com/package/${version.split('@')[0]}`,
+        ? `${defaultUrl}/releases/tag/v${verPart}`
+        : `https://www.npmjs.com/package/${parts[0]}`,
+      displayText: verPart,
+      isCustom: true,
+      isHash: false,
+      isTag: true,
     };
   }
 
@@ -46,22 +64,63 @@ export const getErgogenVersionInfo = (version?: string): VersionInfo => {
     ? version.slice(7)
     : version;
 
-  // Split into repo and branch
+  // Split into repo and branch/ref
   const [repo, branch] = cleanVersion.split('#');
   const isOfficial = repo === 'ergogen/ergogen';
   const baseUrl = `https://github.com/${repo}`;
 
   if (isOfficial) {
     if (!branch) {
-      return { label: 'latest', url: baseUrl };
+      return {
+        label: 'latest',
+        url: baseUrl,
+        displayText: defaultVersion,
+        isCustom: false,
+        isHash: false,
+        isTag: false,
+      };
     }
-    // For official repo, only show the branch/tag
-    return { label: branch, url: `${baseUrl}/tree/${branch}` };
+
+    const isHash = branch.length === 40 && /^[0-9a-fA-F]{40}$/.test(branch);
+    const displayText = isHash ? branch.substring(0, 7) : branch;
+    const url = isHash
+      ? `${baseUrl}/commit/${branch}`
+      : `${baseUrl}/tree/${branch}`;
+
+    return {
+      label: branch,
+      url,
+      displayText,
+      isCustom: true,
+      isHash,
+      isTag: !isHash,
+    };
   }
 
-  // For custom repos, show the full clean version string (e.g., user/repo or user/repo#branch)
+  // For custom repos:
+  if (!branch) {
+    return {
+      label: cleanVersion,
+      url: baseUrl,
+      displayText: defaultVersion,
+      isCustom: true,
+      isHash: false,
+      isTag: false,
+    };
+  }
+
+  const isHash = branch.length === 40 && /^[0-9a-fA-F]{40}$/.test(branch);
+  const displayText = isHash ? branch.substring(0, 7) : branch;
+  const url = isHash
+    ? `${baseUrl}/commit/${branch}`
+    : `${baseUrl}/tree/${branch}`;
+
   return {
     label: cleanVersion,
-    url: branch ? `${baseUrl}/tree/${branch}` : baseUrl,
+    url,
+    displayText,
+    isCustom: true,
+    isHash,
+    isTag: !isHash,
   };
 };


### PR DESCRIPTION
# Add sidebar version displays and custom build indicators

## Description

This PR introduces comprehensive version displays in the sidebar footer and header to improve transparency for users running custom Ergogen builds.

### Key Changes:

1. **Footer Version Buttons**:
   - Replaced the single GitHub footer link with separate, content-sized buttons for the **GUI** (displays local `package.json` version, e.g., `0.6.3`) and **Ergogen** (displays environment build/dependency reference).
   - Removed button `min-width` and layout stretch (`flex: 0 0 auto`) to prevent awkward line wrapping when the sidebar changes width.
   - For custom Ergogen builds (e.g., tag, branch, or hash override), the version text is highlighted in green, and a vertical green `DEV` badge is shown on the right-hand edge.

2. **Commit Hash Truncation**:
   - Upgraded version parser utilities to automatically detect and truncate 40-character commit hashes to 7 characters (e.g., `fb2509f`) and link them directly to GitHub `/commit/` URLs, while leaving shorter labels/tags (e.g., `v4.3.0`) intact and pointing to `/tree/` URLs.

3. **Superscript DEV Beaker Chip**:
   - Removed the old plain version labels next to the logo in the Header and Sidebar.
   - Added a superscript green beaker chip (`DevChip`) next to the "Ergogen" logo text when a custom build is active.
   - Designed the chip as a square badge with rounded corners (`width: 16px; height: 16px; border-radius: 4px;`) containing the centered beaker (`science`) icon.
   - Styled the parent app name element as a flex container using `transform: translateY(-5px)` on the chip so it acts as a superscript badge without shifting the "Ergogen" text baseline down.

4. **Interactive Explanation Modal**:
   - Hovering (desktop) or tapping (mobile) on the beaker chip opens a popover card containing an explanation of the custom version and a link to the repository.
   - Configured a 250ms mouse-leave delay so users can move their mouse into the card to click the link without closing it prematurely.
   - Integrated touch/click-outside listeners to automatically close the popover.

5. **Responsive Adjustments**:
   - Completely hide the logo text ("Ergogen"), the superscript chip, and the divider `/` from the Header on screens `639px` wide and below.
   - Bumped the "+ New" button text hiding breakpoint from `375px` to `510px` to save horizontal space.

6. **Stacking Context Fix**:
   - Set relative positioning and explicit z-indexes on header containers to ensure the custom version popup cards always render on top of inputs, buttons, and panels.

### Tests Verified:
- Added comprehensive unit tests for `DevChip.tsx` (popover toggles, hovers, click-outside close).
- Added rendering tests for version buttons and custom badges in `SideNavigation.test.tsx`.
- Updated all parser unit tests in `version.test.ts`.
- Ran full formatting, linting, and unit test suites successfully (`yarn precommit` passes with 0 warnings/errors).