### PR TITLE
Chore/analytics versions

### DIFF
--- a/src/molecules/SideNavigation.test.tsx
+++ b/src/molecules/SideNavigation.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import SideNavigation from './SideNavigation';
 import { useConfigContext } from '../context/ConfigContext';
+import guiPkg from '../../package.json';
 
 // Mock ConfigContext
 jest.mock('../context/ConfigContext', () => ({
@@ -221,7 +222,7 @@ describe('SideNavigation', () => {
     const guiBtn = screen.getByTestId('side-nav-gui-version-button');
     expect(guiBtn).toBeInTheDocument();
     expect(screen.getByText('GUI')).toBeInTheDocument();
-    expect(screen.getByText('0.6.3')).toBeInTheDocument();
+    expect(screen.getByText(guiPkg.version)).toBeInTheDocument();
 
     // Assert Ergogen button and version
     const ergogenBtn = screen.getByTestId('side-nav-ergogen-version-button');

--- a/src/utils/analytics.test.ts
+++ b/src/utils/analytics.test.ts
@@ -1,19 +1,25 @@
 import { trackEvent } from './analytics';
+import guiPkg from '../../package.json';
+import ergogenPkg from 'ergogen/package.json';
 
 describe('trackEvent', () => {
   const originalGtag = window.gtag;
+  const originalEnv = process.env.REACT_APP_ERGOGEN_VERSION;
 
   beforeEach(() => {
     // Reset window.gtag before each test
     window.gtag = jest.fn();
+    // Reset environment variable before each test
+    process.env.REACT_APP_ERGOGEN_VERSION = originalEnv;
   });
 
   afterAll(() => {
-    // Restore original window.gtag
+    // Restore original window.gtag and environment variable
     window.gtag = originalGtag;
+    process.env.REACT_APP_ERGOGEN_VERSION = originalEnv;
   });
 
-  it('should call window.gtag when it is defined', () => {
+  it('should call window.gtag with GUI and Ergogen versions when it is defined', () => {
     const eventName = 'test_event';
     const eventParams = { param1: 'value1', param2: 123 };
 
@@ -21,18 +27,22 @@ describe('trackEvent', () => {
 
     expect(window.gtag).toHaveBeenCalledWith('event', eventName, {
       event_category: 'user_action',
+      gui_version: guiPkg.version,
+      ergogen_version: `github:ergogen/ergogen#v${ergogenPkg.version}`,
       param1: 'value1',
       param2: 123,
     });
   });
 
-  it('should call window.gtag with default category when eventParams is not provided', () => {
+  it('should call window.gtag with default category and versions when eventParams is not provided', () => {
     const eventName = 'test_event';
 
     trackEvent(eventName);
 
     expect(window.gtag).toHaveBeenCalledWith('event', eventName, {
       event_category: 'user_action',
+      gui_version: guiPkg.version,
+      ergogen_version: `github:ergogen/ergogen#v${ergogenPkg.version}`,
     });
   });
 
@@ -44,6 +54,21 @@ describe('trackEvent', () => {
 
     expect(window.gtag).toHaveBeenCalledWith('event', eventName, {
       event_category: 'custom_category',
+      gui_version: guiPkg.version,
+      ergogen_version: `github:ergogen/ergogen#v${ergogenPkg.version}`,
+    });
+  });
+
+  it('should reflect custom Ergogen versions from environment variables', () => {
+    process.env.REACT_APP_ERGOGEN_VERSION = 'github:ceoloide/ergogen#v4.3.0';
+    const eventName = 'test_event';
+
+    trackEvent(eventName);
+
+    expect(window.gtag).toHaveBeenCalledWith('event', eventName, {
+      event_category: 'user_action',
+      gui_version: guiPkg.version,
+      ergogen_version: 'github:ceoloide/ergogen#v4.3.0',
     });
   });
 

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,3 +1,6 @@
+import guiPkg from '../../package.json';
+import { getFullErgogenVersion } from './version';
+
 /**
  * Utility functions for Google Analytics event tracking.
  */
@@ -12,8 +15,15 @@ export const trackEvent = (
   eventParams?: { [key: string]: string | number | boolean | undefined }
 ): void => {
   if (window.gtag) {
+    const guiVersion = guiPkg.version;
+    const ergogenVersion = getFullErgogenVersion(
+      process.env.REACT_APP_ERGOGEN_VERSION
+    );
+
     window.gtag('event', eventName, {
       event_category: 'user_action',
+      gui_version: guiVersion,
+      ergogen_version: ergogenVersion,
       ...eventParams,
     });
   }

--- a/src/utils/version.test.ts
+++ b/src/utils/version.test.ts
@@ -1,4 +1,4 @@
-import { getErgogenVersionInfo } from './version';
+import { getErgogenVersionInfo, getFullErgogenVersion } from './version';
 import ergogenPkg from 'ergogen/package.json';
 
 describe('getErgogenVersionInfo', () => {
@@ -95,5 +95,70 @@ describe('getErgogenVersionInfo', () => {
       isHash: true,
       isTag: false,
     });
+  });
+});
+
+describe('getFullErgogenVersion', () => {
+  const defaultVersion = ergogenPkg.version;
+
+  it('returns default version when no version is provided', () => {
+    expect(getFullErgogenVersion()).toBe(
+      `github:ergogen/ergogen#v${defaultVersion}`
+    );
+    expect(getFullErgogenVersion('undefined')).toBe(
+      `github:ergogen/ergogen#v${defaultVersion}`
+    );
+    expect(getFullErgogenVersion('null')).toBe(
+      `github:ergogen/ergogen#v${defaultVersion}`
+    );
+  });
+
+  it('returns formatted version for official repo without branch', () => {
+    expect(getFullErgogenVersion('ergogen/ergogen')).toBe(
+      `github:ergogen/ergogen#v${defaultVersion}`
+    );
+  });
+
+  it('returns branch name for official repo with branch', () => {
+    expect(getFullErgogenVersion('ergogen/ergogen#develop')).toBe(
+      'github:ergogen/ergogen#develop'
+    );
+  });
+
+  it('returns default version tag for custom repo without branch', () => {
+    expect(getFullErgogenVersion('ceoloide/ergogen')).toBe(
+      `github:ceoloide/ergogen#v${defaultVersion}`
+    );
+  });
+
+  it('returns custom repo with branch name', () => {
+    expect(getFullErgogenVersion('ceoloide/ergogen#v4.3.0')).toBe(
+      'github:ceoloide/ergogen#v4.3.0'
+    );
+  });
+
+  it('handles github: prefix correctly', () => {
+    expect(getFullErgogenVersion('github:ceoloide/ergogen#develop')).toBe(
+      'github:ceoloide/ergogen#develop'
+    );
+  });
+
+  it('handles NPM versions', () => {
+    expect(getFullErgogenVersion('ergogen@4.2.0')).toBe(
+      'github:ergogen/ergogen#v4.2.0'
+    );
+  });
+
+  it('handles custom NPM packages', () => {
+    expect(getFullErgogenVersion('my-fork-ergogen@4.2.0')).toBe(
+      'github:my-fork-ergogen#v4.2.0'
+    );
+  });
+
+  it('handles 40-character commit hashes correctly', () => {
+    const fullHash = 'fb2509f8e404b9015c7e3ebbd6931754020a2e0a';
+    expect(getFullErgogenVersion(`github:ceoloide/ergogen#${fullHash}`)).toBe(
+      `github:ceoloide/ergogen#${fullHash}`
+    );
   });
 });

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -124,3 +124,39 @@ export const getErgogenVersionInfo = (version?: string): VersionInfo => {
     isTag: !isHash,
   };
 };
+
+/**
+ * Resolves the full Ergogen version string in the format github:user/repo#version-tag.
+ * If the official ergogen is used, it returns github:ergogen/ergogen#v<version>.
+ *
+ * @param version The version string from the environment variable (or config).
+ * @returns The formatted version string.
+ */
+export const getFullErgogenVersion = (version?: string): string => {
+  if (!version || version === 'undefined' || version === 'null') {
+    return `github:ergogen/ergogen#v${ergogenPkg.version}`;
+  }
+
+  // Handle NPM version (e.g., ergogen@4.2.0)
+  if (version.includes('@')) {
+    const parts = version.split('@');
+    const verPart = parts[1] || version;
+    const pkgName = parts[0];
+    const repo = pkgName === 'ergogen' ? 'ergogen/ergogen' : pkgName;
+    return `github:${repo}#v${verPart}`;
+  }
+
+  // Remove "github:" prefix if present for uniform processing
+  const cleanVersion = version.startsWith('github:')
+    ? version.slice(7)
+    : version;
+
+  // Split into repo and branch/ref
+  const [repo, branch] = cleanVersion.split('#');
+
+  if (!branch) {
+    return `github:${repo}#v${ergogenPkg.version}`;
+  }
+
+  return `github:${repo}#${branch}`;
+};


### PR DESCRIPTION
# 🧹 Send GUI and Ergogen versions with Google Analytics events

This PR updates the Google Analytics (GA4) event tracking system to include the current **GUI version** and the **full Ergogen version** as parameters (`gui_version` and `ergogen_version` respectively) on every event. This provides better visibility into user interactions relative to specific builds and Ergogen forks/versions.

### Changes Made
- **Version Helper**: Added `getFullErgogenVersion` in `src/utils/version.ts` to parse the `REACT_APP_ERGOGEN_VERSION` environment variable and resolve it to a standard `github:user/repo#version-tag` format. If using the official build or if it's undefined/null, it defaults to the installed NPM package version (`github:ergogen/ergogen#v<version>`).
- **Analytics Payload**: Updated `trackEvent` in `src/utils/analytics.ts` to retrieve and inject `gui_version` (from `package.json`) and `ergogen_version` into all tracked event payloads.
- **Unit Tests**:
  - Added comprehensive test cases in `src/utils/version.test.ts` verifying all version patterns (NPM tags, branches, hashes, defaults).
  - Updated `src/utils/analytics.test.ts` to assert that version parameters are present on tracked events.
- **Test Fix**: Fixed a regression in `src/molecules/SideNavigation.test.tsx` by replacing a hardcoded stale GUI version check (`0.6.3`) with a dynamic check pointing to `package.json`'s version (`0.6.4`).

### Verification & Testing
- Ran all unit tests with `yarn test:unit` (226/226 passed).
- Executed sanity check with `yarn precommit` (formatting, linting, unused dependencies, unit tests all passed).