### PR TITLE
Implement responsive header/subheader actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Responsive Workspace Header & Subheader Buttons
+
+July 07, 2026
+
+![A view of the responsive workspace at small width showing the Share and Archive buttons moved to the subheader.](./public/images/changelog/placeholder.png)
+
+When using the Ergogen workspace on small screens like mobile devices or narrow browser windows, the header quickly became crowded. Important options like "Archive" and "Share" were squeezed together or pushed out of view, making it hard to download or share your work.
+
+To optimize the workspace layout, we have made the main header and subheader responsive. When the display width is 475px or lower, the "Archive" and "Share" buttons are hidden in the main header and relocated to the subheader. To ensure you only see what is relevant, the "Share" button appears to the left of the "Download" button when editing your configuration, while the "Archive" button appears when viewing your outputs, next to the downloads expand toggle.
+
+**What changed:**
+
+- **Responsive Header Layout**: Hides the "Archive" and "Share" buttons from the top header on display widths of 475px or lower
+- **Subheader "Share" Integration**: Relocates the "Share" button to the configuration subheader to the left of the "Download" button on mobile viewports
+- **Subheader "Archive" Integration**: Relocates the "Archive" button to the outputs subheader to the left of the expand toggle button on mobile viewports
+- **Conditional Subheader Actions**: Automatically displays the correct secondary action button depending on whether "Config" or "Outputs" is selected
+
 ## Sidebar Version Displays & DEV Build Indicators
 
 July 07, 2026

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -295,7 +295,7 @@ The share system provides comprehensive error handling:
   - Preserves existing injections not in the shared config
 - **`src/molecules/ShareDialog.tsx`**: Dialog component for displaying and copying share links
 - **`src/App.tsx`**: Handles initial hash fragment loading and hash change events
-- **`src/atoms/Header.tsx`**: Contains the share button and share functionality. The share button is visible on the main page (`/`) but hidden on the Welcome page (`/new`). It's also visible on mobile devices.
+- **`src/atoms/Header.tsx`**: Contains the share button and share functionality. The share button is visible on the main page (`/`) but hidden on the Welcome page (`/new`). On displays 475px or wider, it is visible in the main header. On displays 475px or narrower, it is hidden in the header and shown in the subheader (inside `src/Ergogen.tsx`).
 
 ### Future Enhancements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ergogen-gui",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "A web-based GUI for Ergogen, the ergonomic keyboard layout generator.",
   "license": "MIT",
   "private": false,

--- a/src/Ergogen.test.tsx
+++ b/src/Ergogen.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Ergogen from './Ergogen';
+import { useConfigContext } from './context/ConfigContext';
+
+jest.mock('./context/ConfigContext', () => ({
+  useConfigContext: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => jest.fn(),
+  useLocation: () => ({ pathname: '/' }),
+}));
+
+jest.mock('react-hotkeys-hook', () => ({
+  useHotkeys: jest.fn(),
+}));
+
+// Mock sub-components
+jest.mock('./molecules/ConfigEditor', () => {
+  const MockConfigEditor = () => <div data-testid="mock-config-editor" />;
+  MockConfigEditor.displayName = 'MockConfigEditor';
+  return MockConfigEditor;
+});
+jest.mock('./molecules/InjectionEditor', () => {
+  const MockInjectionEditor = () => <div data-testid="mock-injection-editor" />;
+  MockInjectionEditor.displayName = 'MockInjectionEditor';
+  return MockInjectionEditor;
+});
+jest.mock('./molecules/Downloads', () => {
+  const MockDownloads = () => <div data-testid="mock-downloads" />;
+  MockDownloads.displayName = 'MockDownloads';
+  return MockDownloads;
+});
+jest.mock('./molecules/Injections', () => {
+  const MockInjections = () => <div data-testid="mock-injections" />;
+  MockInjections.displayName = 'MockInjections';
+  return MockInjections;
+});
+jest.mock('./molecules/FilePreview', () => {
+  const MockFilePreview = () => <div data-testid="mock-file-preview" />;
+  MockFilePreview.displayName = 'MockFilePreview';
+  return MockFilePreview;
+});
+jest.mock('./molecules/ResizablePanel', () => {
+  const MockResizablePanel = ({ children }: any) => <div>{children}</div>;
+  MockResizablePanel.displayName = 'MockResizablePanel';
+  return MockResizablePanel;
+});
+
+// Mock zip, share, and analytics utils
+const mockCreateZip = jest.fn();
+jest.mock('./utils/zip', () => ({
+  createZip: (...args: any[]) => mockCreateZip(...args),
+}));
+
+const mockCreateShareableUri = jest.fn().mockReturnValue('https://share.link');
+jest.mock('./utils/share', () => ({
+  createShareableUri: (...args: any[]) => mockCreateShareableUri(...args),
+}));
+
+const mockTrackEvent = jest.fn();
+jest.mock('./utils/analytics', () => ({
+  trackEvent: (...args: any[]) => mockTrackEvent(...args),
+}));
+
+describe('Ergogen Subheader Buttons', () => {
+  const mockContextValue = {
+    configs: [],
+    activeConfigId: '1',
+    activeConfigName: 'My Awesome Board',
+    isPreview: false,
+    results: null,
+    configInput: 'points: {}',
+    injectionInput: [],
+    debug: false,
+    stlPreview: false,
+    isGenerating: false,
+    isJscadConverting: false,
+    showSettings: false,
+    showSideNav: false,
+    showConfig: true,
+    showDownloads: false,
+    setShowSettings: jest.fn(),
+    setShowSideNav: jest.fn(),
+    setShowConfig: jest.fn(),
+    setShowDownloads: jest.fn(),
+    generateNow: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useConfigContext as jest.Mock).mockReturnValue(mockContextValue);
+  });
+
+  it('renders mobile share button and triggers share logic on click when showConfig is true', () => {
+    render(<Ergogen />);
+    const shareBtn = screen.getByTestId('mobile-share-button');
+    expect(shareBtn).toBeInTheDocument();
+
+    fireEvent.click(shareBtn);
+    expect(mockCreateShareableUri).toHaveBeenCalledWith({
+      config: 'points: {}',
+      injections: [],
+      canonical: undefined,
+    });
+    expect(
+      screen.getByText('Shareable Configuration Link')
+    ).toBeInTheDocument();
+  });
+
+  it('renders mobile archive button and triggers download archive logic on click when showConfig is false', () => {
+    (useConfigContext as jest.Mock).mockReturnValue({
+      ...mockContextValue,
+      showConfig: false,
+      results: { canonical: 'canonical_yaml' },
+    });
+    render(<Ergogen />);
+    const archiveBtn = screen.getByTestId('mobile-download-outputs-button');
+    expect(archiveBtn).toBeInTheDocument();
+
+    fireEvent.click(archiveBtn);
+    expect(mockCreateZip).toHaveBeenCalledWith(
+      { canonical: 'canonical_yaml' },
+      'points: {}',
+      [],
+      false,
+      false
+    );
+  });
+});

--- a/src/Ergogen.tsx
+++ b/src/Ergogen.tsx
@@ -29,6 +29,9 @@ import Title from './atoms/Title';
 import { theme } from './theme/theme';
 
 import { trackEvent } from './utils/analytics';
+import ShareDialog from './molecules/ShareDialog';
+import { createZip } from './utils/zip';
+import { createShareableUri } from './utils/share';
 
 // Shortcut key sub-label styled component
 const ShortcutKey = styled.span`
@@ -82,6 +85,14 @@ const SubHeaderContainer = styled.div`
  */
 const Spacer = styled.div`
   flex-grow: 1;
+`;
+
+const SubHeaderResponsiveIconButton = styled(OutlineIconButton)`
+  display: none;
+
+  @media (max-width: 475px) {
+    display: flex;
+  }
 `;
 
 /**
@@ -285,6 +296,9 @@ const Ergogen = () => {
     extension: 'svg',
     content: '',
   });
+
+  const [shareLink, setShareLink] = useState('');
+  const [showShareDialog, setShowShareDialog] = useState(false);
 
   /**
    * Wrapper function to set preview and hide downloads panel.
@@ -495,125 +509,223 @@ const Ergogen = () => {
     document.body.removeChild(element);
   };
 
+  const handleShare = () => {
+    if (!configContext.configInput) {
+      return;
+    }
+
+    const shareableUri = createShareableUri({
+      config: configContext.configInput,
+      injections: configContext.injectionInput,
+      canonical: configContext.results?.canonical,
+    });
+
+    trackEvent('share_button_clicked', {
+      has_injections: !!configContext.injectionInput?.length,
+      injections_count: configContext.injectionInput?.length || 0,
+      source: 'subheader',
+    });
+
+    setShareLink(shareableUri);
+    setShowShareDialog(true);
+  };
+
+  const handleDownloadArchive = () => {
+    if (
+      !configContext.results ||
+      !configContext.configInput ||
+      configContext.isGenerating ||
+      configContext.isJscadConverting
+    ) {
+      return;
+    }
+    trackEvent('archive_single_downloaded', {
+      has_injections: !!configContext.injectionInput?.length,
+      injections_count: configContext.injectionInput?.length || 0,
+      stored_configs_count: configContext.configs?.length || 0,
+      source: 'subheader',
+    });
+    createZip(
+      configContext.results,
+      configContext.configInput,
+      configContext.injectionInput,
+      configContext.debug,
+      configContext.stlPreview
+    );
+  };
+
   return (
-    <ErgogenWrapper>
-      {!configContext.showSettings && (
-        <SubHeaderContainer>
-          <OutlineIconButton
-            className={configContext.showConfig ? 'active' : ''}
-            onClick={() => configContext.setShowConfig(true)}
-            aria-label="Show configuration panel"
-            data-testid="mobile-config-button"
-          >
-            Config
-          </OutlineIconButton>
-          <OutlineIconButton
-            className={!configContext.showConfig ? 'active' : ''}
-            onClick={() => configContext.setShowConfig(false)}
-            aria-label="Show outputs panel"
-            data-testid="mobile-outputs-button"
-          >
-            Outputs
-          </OutlineIconButton>
-          <Spacer />
-          {configContext.showConfig && (
-            <>
-              <GenerateIconButton
-                onClick={() =>
-                  configContext.generateNow(
-                    configContext.configInput,
-                    configContext.injectionInput,
-                    { pointsonly: false }
-                  )
-                }
-                aria-label="Generate configuration"
-                data-testid="mobile-generate-button"
-              >
-                <span className="material-symbols-outlined">refresh</span>
-              </GenerateIconButton>
-              <OutlineIconButton
-                onClick={handleDownload}
-                aria-label="Download configuration"
-                data-testid="mobile-download-button"
-              >
-                <span className="material-symbols-outlined">download</span>
-              </OutlineIconButton>
-            </>
-          )}
-          {!configContext.showConfig && (
-            <OutlineIconButton
-              onClick={() =>
-                configContext.setShowDownloads(!configContext.showDownloads)
-              }
-              aria-label={
-                configContext.showDownloads
-                  ? 'Hide downloads panel'
-                  : 'Show downloads panel'
-              }
-              data-testid="mobile-downloads-toggle-button"
-            >
-              <span className="material-symbols-outlined">
-                {configContext.showDownloads
-                  ? 'expand_content'
-                  : 'collapse_content'}
-              </span>
-            </OutlineIconButton>
-          )}
-        </SubHeaderContainer>
+    <>
+      {showShareDialog && (
+        <ShareDialog
+          shareLink={shareLink}
+          onClose={() => setShowShareDialog(false)}
+        />
       )}
-      <FlexContainer>
-        {!configContext.showSettings ? (
-          <>
+      <ErgogenWrapper>
+        {!configContext.showSettings && (
+          <SubHeaderContainer>
+            <OutlineIconButton
+              className={configContext.showConfig ? 'active' : ''}
+              onClick={() => configContext.setShowConfig(true)}
+              aria-label="Show configuration panel"
+              data-testid="mobile-config-button"
+            >
+              Config
+            </OutlineIconButton>
+            <OutlineIconButton
+              className={!configContext.showConfig ? 'active' : ''}
+              onClick={() => configContext.setShowConfig(false)}
+              aria-label="Show outputs panel"
+              data-testid="mobile-outputs-button"
+            >
+              Outputs
+            </OutlineIconButton>
+            <Spacer />
             {configContext.showConfig && (
-              <ResizablePanel
-                initialWidth={getInitialLeftWidth()}
-                minWidth={250}
-                maxWidth="60%"
-                side="left"
-                data-testid="config-panel"
-              >
-                <EditorContainer>
-                  <StyledConfigEditor data-testid="config-editor" />
-                  <ButtonContainer>
-                    <GrowButton
-                      onClick={() =>
-                        configContext.generateNow(
-                          configContext.configInput,
-                          configContext.injectionInput,
-                          { pointsonly: false }
-                        )
-                      }
-                      aria-label="Generate configuration"
-                      data-testid="generate-button"
-                    >
-                      <span
-                        style={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          width: '100%',
-                          justifyContent: 'center',
-                        }}
-                      >
-                        <span>Generate</span>
-                        <ShortcutKey>{getShortcutLabel()}</ShortcutKey>
-                      </span>
-                    </GrowButton>
-                    <OutlineIconButton
-                      onClick={handleDownload}
-                      aria-label="Download configuration"
-                      data-testid="download-config-button"
-                    >
-                      <span className="material-symbols-outlined">
-                        download
-                      </span>
-                    </OutlineIconButton>
-                  </ButtonContainer>
-                </EditorContainer>
-              </ResizablePanel>
+              <>
+                <GenerateIconButton
+                  onClick={() =>
+                    configContext.generateNow(
+                      configContext.configInput,
+                      configContext.injectionInput,
+                      { pointsonly: false }
+                    )
+                  }
+                  aria-label="Generate configuration"
+                  data-testid="mobile-generate-button"
+                >
+                  <span className="material-symbols-outlined">refresh</span>
+                </GenerateIconButton>
+                <SubHeaderResponsiveIconButton
+                  onClick={handleShare}
+                  disabled={!configContext.configInput}
+                  aria-label="Share configuration"
+                  data-testid="mobile-share-button"
+                >
+                  <span className="material-symbols-outlined">share</span>
+                </SubHeaderResponsiveIconButton>
+                <OutlineIconButton
+                  onClick={handleDownload}
+                  aria-label="Download configuration"
+                  data-testid="mobile-download-button"
+                >
+                  <span className="material-symbols-outlined">download</span>
+                </OutlineIconButton>
+              </>
             )}
-            <RightPane>
-              {configContext.showDownloads ? (
-                <>
+            {!configContext.showConfig && (
+              <>
+                <SubHeaderResponsiveIconButton
+                  onClick={handleDownloadArchive}
+                  disabled={
+                    configContext.isGenerating ||
+                    configContext.isJscadConverting
+                  }
+                  aria-label="Download archive of all generated files"
+                  data-testid="mobile-download-outputs-button"
+                >
+                  <span className="material-symbols-outlined">archive</span>
+                </SubHeaderResponsiveIconButton>
+                <OutlineIconButton
+                  onClick={() =>
+                    configContext.setShowDownloads(!configContext.showDownloads)
+                  }
+                  aria-label={
+                    configContext.showDownloads
+                      ? 'Hide downloads panel'
+                      : 'Show downloads panel'
+                  }
+                  data-testid="mobile-downloads-toggle-button"
+                >
+                  <span className="material-symbols-outlined">
+                    {configContext.showDownloads
+                      ? 'expand_content'
+                      : 'collapse_content'}
+                  </span>
+                </OutlineIconButton>
+              </>
+            )}
+          </SubHeaderContainer>
+        )}
+        <FlexContainer>
+          {!configContext.showSettings ? (
+            <>
+              {configContext.showConfig && (
+                <ResizablePanel
+                  initialWidth={getInitialLeftWidth()}
+                  minWidth={250}
+                  maxWidth="60%"
+                  side="left"
+                  data-testid="config-panel"
+                >
+                  <EditorContainer>
+                    <StyledConfigEditor data-testid="config-editor" />
+                    <ButtonContainer>
+                      <GrowButton
+                        onClick={() =>
+                          configContext.generateNow(
+                            configContext.configInput,
+                            configContext.injectionInput,
+                            { pointsonly: false }
+                          )
+                        }
+                        aria-label="Generate configuration"
+                        data-testid="generate-button"
+                      >
+                        <span
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            width: '100%',
+                            justifyContent: 'center',
+                          }}
+                        >
+                          <span>Generate</span>
+                          <ShortcutKey>{getShortcutLabel()}</ShortcutKey>
+                        </span>
+                      </GrowButton>
+                      <OutlineIconButton
+                        onClick={handleDownload}
+                        aria-label="Download configuration"
+                        data-testid="download-config-button"
+                      >
+                        <span className="material-symbols-outlined">
+                          download
+                        </span>
+                      </OutlineIconButton>
+                    </ButtonContainer>
+                  </EditorContainer>
+                </ResizablePanel>
+              )}
+              <RightPane>
+                {configContext.showDownloads ? (
+                  <>
+                    <NestedRightPane>
+                      <StyledFilePreview
+                        data-testid={`${preview.key}-file-preview`}
+                        previewExtension={preview.extension}
+                        previewKey={`${preview.key}-${configContext.resultsVersion}`}
+                        previewContent={preview.content}
+                      />
+                    </NestedRightPane>
+                    <ResizablePanel
+                      initialWidth={getInitialRightWidth()}
+                      minWidth={105}
+                      maxWidth="30%"
+                      side="right"
+                      data-testid="downloads-panel"
+                    >
+                      <ScrollablePanelContainer>
+                        <Downloads
+                          setPreview={handleSetPreview}
+                          previewKey={preview.key}
+                          data-testid="downloads-container"
+                        />
+                      </ScrollablePanelContainer>
+                    </ResizablePanel>
+                  </>
+                ) : (
                   <NestedRightPane>
                     <StyledFilePreview
                       data-testid={`${preview.key}-file-preview`}
@@ -622,168 +734,144 @@ const Ergogen = () => {
                       previewContent={preview.content}
                     />
                   </NestedRightPane>
-                  <ResizablePanel
-                    initialWidth={getInitialRightWidth()}
-                    minWidth={105}
-                    maxWidth="30%"
-                    side="right"
-                    data-testid="downloads-panel"
-                  >
-                    <ScrollablePanelContainer>
-                      <Downloads
-                        setPreview={handleSetPreview}
-                        previewKey={preview.key}
-                        data-testid="downloads-container"
-                      />
-                    </ScrollablePanelContainer>
-                  </ResizablePanel>
-                </>
-              ) : (
-                <NestedRightPane>
-                  <StyledFilePreview
-                    data-testid={`${preview.key}-file-preview`}
-                    previewExtension={preview.extension}
-                    previewKey={`${preview.key}-${configContext.resultsVersion}`}
-                    previewContent={preview.content}
+                )}
+              </RightPane>
+            </>
+          ) : (
+            <>
+              <ResizablePanel
+                initialWidth={getInitialSettingsWidth()}
+                minWidth={150}
+                maxWidth="70%"
+                side="left"
+                data-testid="settings-panel"
+                style={{
+                  display: showMobileEditor && isMobile ? 'none' : undefined,
+                }}
+              >
+                <SettingsPaneContainer>
+                  <OptionContainer>
+                    <Title>Options</Title>
+                    <GenOption
+                      optionId={'autogen'}
+                      label={'Auto-generate'}
+                      setSelected={configContext.setAutoGen}
+                      checked={configContext.autoGen}
+                      aria-label="Enable auto-generate"
+                    />
+                    <GenOption
+                      optionId={'debug'}
+                      label={'Debug'}
+                      setSelected={configContext.setDebug}
+                      checked={configContext.debug}
+                      aria-label="Enable debug mode"
+                    />
+                    <GenOption
+                      optionId={'autogen3d'}
+                      label={
+                        <>
+                          Auto-gen PCB, 3D <small>(slow)</small>
+                        </>
+                      }
+                      setSelected={configContext.setAutoGen3D}
+                      checked={configContext.autoGen3D}
+                      aria-label="Enable auto-generate PCB and 3D (slow)"
+                    />
+                    <GenOption
+                      optionId={'kicanvasPreview'}
+                      label={
+                        <>
+                          KiCad Preview <small>(experimental)</small>
+                        </>
+                      }
+                      setSelected={configContext.setKicanvasPreview}
+                      checked={configContext.kicanvasPreview}
+                      aria-label="Enable KiCad preview (experimental)"
+                    />
+                    <GenOption
+                      optionId={'stlPreview'}
+                      label={
+                        <>
+                          STL Preview <small>(experimental)</small>
+                        </>
+                      }
+                      setSelected={configContext.setStlPreview}
+                      checked={configContext.stlPreview}
+                      aria-label="Enable STL preview (experimental)"
+                    />
+                  </OptionContainer>
+                  <Injections
+                    setInjectionToEdit={setInjectionToEdit}
+                    deleteInjection={handleDeleteInjection}
+                    injectionToEdit={injectionToEdit}
+                    onInjectionSelect={() => setShowMobileEditor(true)}
+                    data-testid="injections-container"
                   />
-                </NestedRightPane>
-              )}
-            </RightPane>
-          </>
-        ) : (
-          <>
-            <ResizablePanel
-              initialWidth={getInitialSettingsWidth()}
-              minWidth={150}
-              maxWidth="70%"
-              side="left"
-              data-testid="settings-panel"
-              style={{
-                display: showMobileEditor && isMobile ? 'none' : undefined,
-              }}
-            >
-              <SettingsPaneContainer>
-                <OptionContainer>
-                  <Title>Options</Title>
-                  <GenOption
-                    optionId={'autogen'}
-                    label={'Auto-generate'}
-                    setSelected={configContext.setAutoGen}
-                    checked={configContext.autoGen}
-                    aria-label="Enable auto-generate"
-                  />
-                  <GenOption
-                    optionId={'debug'}
-                    label={'Debug'}
-                    setSelected={configContext.setDebug}
-                    checked={configContext.debug}
-                    aria-label="Enable debug mode"
-                  />
-                  <GenOption
-                    optionId={'autogen3d'}
-                    label={
-                      <>
-                        Auto-gen PCB, 3D <small>(slow)</small>
-                      </>
-                    }
-                    setSelected={configContext.setAutoGen3D}
-                    checked={configContext.autoGen3D}
-                    aria-label="Enable auto-generate PCB and 3D (slow)"
-                  />
-                  <GenOption
-                    optionId={'kicanvasPreview'}
-                    label={
-                      <>
-                        KiCad Preview <small>(experimental)</small>
-                      </>
-                    }
-                    setSelected={configContext.setKicanvasPreview}
-                    checked={configContext.kicanvasPreview}
-                    aria-label="Enable KiCad preview (experimental)"
-                  />
-                  <GenOption
-                    optionId={'stlPreview'}
-                    label={
-                      <>
-                        STL Preview <small>(experimental)</small>
-                      </>
-                    }
-                    setSelected={configContext.setStlPreview}
-                    checked={configContext.stlPreview}
-                    aria-label="Enable STL preview (experimental)"
-                  />
-                </OptionContainer>
-                <Injections
-                  setInjectionToEdit={setInjectionToEdit}
-                  deleteInjection={handleDeleteInjection}
-                  injectionToEdit={injectionToEdit}
-                  onInjectionSelect={() => setShowMobileEditor(true)}
-                  data-testid="injections-container"
-                />
-              </SettingsPaneContainer>
-            </ResizablePanel>
-            <RightPane $fullWidth={showMobileEditor && isMobile}>
-              <EditorContainer>
-                {isMobile && (
-                  <MobileEditorHeader>
-                    <Title as="h4" style={{ marginTop: 0 }}>
+                </SettingsPaneContainer>
+              </ResizablePanel>
+              <RightPane $fullWidth={showMobileEditor && isMobile}>
+                <EditorContainer>
+                  {isMobile && (
+                    <MobileEditorHeader>
+                      <Title as="h4" style={{ marginTop: 0 }}>
+                        {injectionToEdit.type
+                          ? injectionToEdit.type.charAt(0).toUpperCase() +
+                            injectionToEdit.type.slice(1)
+                          : 'Footprint'}{' '}
+                        name
+                      </Title>
+                      <MobileCloseButton
+                        onClick={() => {
+                          setShowMobileEditor(false);
+                          setInjectionToEdit({
+                            key: -1,
+                            type: '',
+                            name: '',
+                            content: '',
+                          });
+                        }}
+                        aria-label="Close editor"
+                        data-testid="mobile-editor-close"
+                      >
+                        <span className="material-symbols-outlined">close</span>
+                      </MobileCloseButton>
+                    </MobileEditorHeader>
+                  )}
+                  {!isMobile && (
+                    <Title as="h4">
                       {injectionToEdit.type
                         ? injectionToEdit.type.charAt(0).toUpperCase() +
                           injectionToEdit.type.slice(1)
                         : 'Footprint'}{' '}
                       name
                     </Title>
-                    <MobileCloseButton
-                      onClick={() => {
-                        setShowMobileEditor(false);
-                        setInjectionToEdit({
-                          key: -1,
-                          type: '',
-                          name: '',
-                          content: '',
-                        });
-                      }}
-                      aria-label="Close editor"
-                      data-testid="mobile-editor-close"
-                    >
-                      <span className="material-symbols-outlined">close</span>
-                    </MobileCloseButton>
-                  </MobileEditorHeader>
-                )}
-                {!isMobile && (
+                  )}
+                  <Input
+                    value={injectionToEdit.name}
+                    onChange={handleInjectionNameChange}
+                    disabled={injectionToEdit.key === -1}
+                    aria-label={`${injectionToEdit.type ? injectionToEdit.type.charAt(0).toUpperCase() + injectionToEdit.type.slice(1) : 'Footprint'} name`}
+                    data-testid="footprint-name-input"
+                  />
                   <Title as="h4">
                     {injectionToEdit.type
                       ? injectionToEdit.type.charAt(0).toUpperCase() +
                         injectionToEdit.type.slice(1)
                       : 'Footprint'}{' '}
-                    name
+                    code
                   </Title>
-                )}
-                <Input
-                  value={injectionToEdit.name}
-                  onChange={handleInjectionNameChange}
-                  disabled={injectionToEdit.key === -1}
-                  aria-label={`${injectionToEdit.type ? injectionToEdit.type.charAt(0).toUpperCase() + injectionToEdit.type.slice(1) : 'Footprint'} name`}
-                  data-testid="footprint-name-input"
-                />
-                <Title as="h4">
-                  {injectionToEdit.type
-                    ? injectionToEdit.type.charAt(0).toUpperCase() +
-                      injectionToEdit.type.slice(1)
-                    : 'Footprint'}{' '}
-                  code
-                </Title>
-                <InjectionEditor
-                  injection={injectionToEdit}
-                  setInjection={setInjectionToEdit}
-                  options={{ readOnly: injectionToEdit.key === -1 }}
-                />
-              </EditorContainer>
-            </RightPane>
-          </>
-        )}
-      </FlexContainer>
-    </ErgogenWrapper>
+                  <InjectionEditor
+                    injection={injectionToEdit}
+                    setInjection={setInjectionToEdit}
+                    options={{ readOnly: injectionToEdit.key === -1 }}
+                  />
+                </EditorContainer>
+              </RightPane>
+            </>
+          )}
+        </FlexContainer>
+      </ErgogenWrapper>
+    </>
   );
 };
 

--- a/src/atoms/Header.test.tsx
+++ b/src/atoms/Header.test.tsx
@@ -8,6 +8,16 @@ jest.mock('../context/ConfigContext', () => ({
   useConfigContext: jest.fn(),
 }));
 
+const mockCreateZip = jest.fn();
+jest.mock('../utils/zip', () => ({
+  createZip: (...args: any[]) => mockCreateZip(...args),
+}));
+
+const mockCreateShareableUri = jest.fn().mockReturnValue('https://share.link');
+jest.mock('../utils/share', () => ({
+  createShareableUri: (...args: any[]) => mockCreateShareableUri(...args),
+}));
+
 const mockNavigate = jest.fn();
 const mockLocation = { pathname: '/' };
 jest.mock('react-router-dom', () => ({
@@ -156,5 +166,39 @@ describe('Header', () => {
     fireEvent.click(saveBtn);
 
     expect(mockContextValue.savePreviewConfig).toHaveBeenCalled();
+  });
+
+  it('triggers download archive on click', () => {
+    (useConfigContext as jest.Mock).mockReturnValue({
+      ...mockContextValue,
+      results: { canonical: 'canonical_yaml' },
+      configInput: 'points: {}',
+    });
+    renderComponent();
+    const downloadOutputsBtn = screen.getByTestId(
+      'header-download-outputs-button'
+    );
+    fireEvent.click(downloadOutputsBtn);
+    expect(mockCreateZip).toHaveBeenCalledWith(
+      { canonical: 'canonical_yaml' },
+      'points: {}',
+      [],
+      false,
+      false
+    );
+  });
+
+  it('triggers share dialog on click', () => {
+    renderComponent();
+    const shareBtn = screen.getByTestId('header-share-button');
+    fireEvent.click(shareBtn);
+    expect(mockCreateShareableUri).toHaveBeenCalledWith({
+      config: 'points: {}',
+      injections: [],
+      canonical: undefined,
+    });
+    expect(
+      screen.getByText('Shareable Configuration Link')
+    ).toBeInTheDocument();
   });
 });

--- a/src/atoms/Header.tsx
+++ b/src/atoms/Header.tsx
@@ -442,7 +442,7 @@ const Header = (): JSX.Element => {
                       >
                         <span className="material-symbols-outlined">edit</span>
                       </HeaderActionIconBtn>
-                      <HeaderActionIconBtn
+                      <HeaderActionSecondaryBtn
                         onClick={handleDuplicate}
                         aria-label="Duplicate configuration"
                         data-testid="header-duplicate-btn"
@@ -450,8 +450,8 @@ const Header = (): JSX.Element => {
                         <span className="material-symbols-outlined">
                           content_copy
                         </span>
-                      </HeaderActionIconBtn>
-                      <HeaderActionIconBtn
+                      </HeaderActionSecondaryBtn>
+                      <HeaderActionSecondaryBtn
                         onClick={handleDelete}
                         aria-label="Delete configuration"
                         data-testid="header-delete-btn"
@@ -459,7 +459,7 @@ const Header = (): JSX.Element => {
                         <span className="material-symbols-outlined">
                           delete
                         </span>
-                      </HeaderActionIconBtn>
+                      </HeaderActionSecondaryBtn>
                     </HeaderItemActions>
                   </>
                 )}
@@ -589,6 +589,12 @@ const HeaderActionIconBtn = styled.button`
   &:hover {
     background-color: ${theme.colors.buttonHover};
     color: ${theme.colors.white};
+  }
+`;
+
+const HeaderActionSecondaryBtn = styled(HeaderActionIconBtn)`
+  @media (max-width: 767px) {
+    display: none;
   }
 `;
 

--- a/src/atoms/Header.tsx
+++ b/src/atoms/Header.tsx
@@ -134,7 +134,11 @@ const NewButtonText = styled.span`
   }
 `;
 
-const ArchiveIconButton = styled(OutlineIconButton)``;
+const ArchiveIconButton = styled(OutlineIconButton)`
+  @media (max-width: 475px) {
+    display: none;
+  }
+`;
 
 /**
  * A responsive button that is only visible on smaller screens.

--- a/src/atoms/Header.tsx
+++ b/src/atoms/Header.tsx
@@ -126,6 +126,10 @@ const AccentIconButton = styled(OutlineIconButton)`
     background-color: ${theme.colors.accentDark};
     border-color: ${theme.colors.accentDarker};
   }
+
+  @media (max-width: 375px) {
+    display: none;
+  }
 `;
 
 const NewButtonText = styled.span`

--- a/src/molecules/SideNavigation.tsx
+++ b/src/molecules/SideNavigation.tsx
@@ -30,10 +30,10 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
 }) => {
   const prevIsOpenRef = useRef(isOpen);
   const [isOpening, setIsOpening] = useState(isOpen);
-  const [panelWidth, setPanelWidth] = useState(320);
+  const [panelWidth, setPanelWidth] = useState(345);
   const isResizingRef = useRef(false);
   const startXRef = useRef(0);
-  const startWidthRef = useRef(320);
+  const startWidthRef = useRef(345);
 
   const configContext = useConfigContext();
   const navigate = useNavigate();
@@ -180,7 +180,7 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
       const deltaX = e.clientX - startXRef.current;
       const newWidth = startWidthRef.current + deltaX;
       const maxWidth = Math.min(600, window.innerWidth * 0.9);
-      const constrainedWidth = Math.max(320, Math.min(newWidth, maxWidth));
+      const constrainedWidth = Math.max(345, Math.min(newWidth, maxWidth));
       setPanelWidth(constrainedWidth);
     };
 
@@ -199,7 +199,7 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
       const deltaX = touch.clientX - startXRef.current;
       const newWidth = startWidthRef.current + deltaX;
       const maxWidth = Math.min(600, window.innerWidth * 0.9);
-      const constrainedWidth = Math.max(320, Math.min(newWidth, maxWidth));
+      const constrainedWidth = Math.max(345, Math.min(newWidth, maxWidth));
       setPanelWidth(constrainedWidth);
     };
 


### PR DESCRIPTION
# Implement responsive header/subheader actions

This pull request optimizes the Ergogen Web UI workspace layout for mobile viewports and narrow screens, and increases the default side navigation panel width for improved readability of configuration names.

### Key Changes

1. **Responsive Header & Subheader Actions (Width <= 475px)**:
   - Hides the **Archive** and **Share** buttons from the main top Header.
   - Relocates them into the mobile Subheader based on the active tab context:
     - **Share** button is shown to the left of the **Download** button when `Config` is selected.
     - **Archive** button is shown to the left of the expand toggle button when `Outputs` is selected.

2. **Ultra-Narrow Screen Optimization (Width <= 375px)**:
   - Hides the **+ New** button from the main Header to avoid overlapping layout items.

3. **Config Name Chip Actions (Width <= 767px)**:
   - Hides the **Duplicate (Copy)** and **Delete** buttons from the config name chip in the Header to declutter the workspace title area on medium/small viewports.

4. **Default Side Navigation Width**:
   - Increased the default starting width and minimum resizing constraint of the sidebar navigation panel from `320px` to `345px` to provide better visibility for configuration names.

### Verification & Testing
- Added unit tests in `src/atoms/Header.test.tsx` verifying the Archive and Share button click triggers.
- Created `src/Ergogen.test.tsx` containing tests that assert the presence and functions of the new subheader action buttons under mobile conditions.
- Ran all verification commands (`yarn precommit` which runs `format`, `lint`, and `test:unit`) successfully.