### PR TITLE
Filter custom libraries by actual usage when sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Smarter Share: Choose What to Include
+
+July 08, 2026
+
+![A view of the new Share modal showing the Include custom libraries toggle, a loading spinner, and a checklist of custom footprints and templates with checkboxes.](./public/images/changelog/placeholder.png)
+
+When sharing a keyboard configuration that uses custom footprints or templates, the previous flow automatically bundled all loaded custom libraries into the share link — even ones that weren't actually referenced by the current design. This made links unnecessarily large and risked including work-in-progress libraries you didn't intend to share.
+
+The new Share modal gives you full control. Before generating the link, a first step lets you review exactly which custom libraries will be included. The app silently analyzes your configuration in the background and intelligently filters the list: only footprints that are actually used in your PCB layout are shown, while unused ones are automatically excluded. Templates and outline libraries are always surfaced for review since they affect the whole design. Each item has a checkbox so you can include or exclude it individually.
+
+If you don't want to include any custom libraries at all — for example, when the recipient has their own copy — just toggle "Include custom libraries" off and only the raw configuration text is shared. Once you're happy with the selection, click "Share" to generate the link, which is then automatically copied to your clipboard.
+
+**What changed:**
+
+- **Two-step Share modal**: A new selection step lets you review and choose which custom libraries to include before the link is generated
+- **Smart footprint filtering**: The app runs a background analysis to identify which footprints are actually used in your design, hiding unused ones from the list
+- **"Include custom libraries" toggle**: Quickly opt out of sharing any custom libraries with a single switch (defaults to ON)
+- **Per-item checkboxes**: Fine-grained control to include or exclude individual footprints, templates, or outline libraries
+- **Type badges**: Each library in the list is labeled with its type (footprint, template, or outline) for easy identification
+
 ## Responsive Workspace Header & Subheader Buttons
 
 July 07, 2026

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -216,30 +216,41 @@ The application supports sharing keyboard configurations via URL hash fragments.
 Shareable links use the format: `https://ergogen.io/#<encoded-config>` where the hash fragment contains:
 
 - The keyboard configuration (YAML/JSON string)
-- Only the footprint injections that are actually used in the configuration's PCBs section
-- All non-footprint injections (templates, etc.) are always included
+- Only the footprint injections that were selected by the user in the Share dialog (filtered to those actually used in the design)
+- All non-footprint injections (templates, etc.) that were selected by the user
 
 The configuration and injections are compressed and URL-encoded using `lz-string`'s `compressToEncodedURIComponent` function for efficient transmission.
 
 ### Sharing Process
 
-1. **Generation**: When the user clicks the share button, the app:
-   - Collects the current configuration and canonical output
-   - Extracts used footprint names from the canonical output's PCBs section (`pcbs[*].footprints[*].what`)
-   - Filters injections to only include footprints that are used (non-footprint injections like templates are always included)
-   - Encodes them into a `ShareableConfig` object (with optional `injections` field)
-   - Compresses and URL-encodes the JSON representation
-   - Constructs a full URL with the encoded data in the hash fragment
-   - Displays a `ShareDialog` with the link
+The sharing flow is a two-step wizard inside `ShareDialog`:
 
-2. **Auto-copy**: The share link is automatically copied to the clipboard when the dialog opens
+**Step 1 – Selection View:**
 
-3. **Dialog UI**: The `ShareDialog` component provides:
-   - A read-only input field showing the shareable link
-   - A "Copy link" button with visual feedback (changes to "Link copied" with check icon for 2.5 seconds)
-   - Close button (X) in the top right corner
-   - Keyboard support (Escape key closes the dialog)
-   - Responsive layout that wraps the button to a new line on narrow screens
+1. The user clicks the share button in the header or subheader. The `ShareDialog` opens at Step 1.
+2. An **"Include custom libraries"** toggle is shown (defaulted to ON).
+3. When ON and custom injections are present, the dialog immediately spawns a **temporary background worker** (via `createErgogenWorker()`) and runs Ergogen generation in debug mode.
+4. The worker response includes the `canonical` output. The dialog calls `extractUsedFootprintsFromCanonical(canonical)` to identify which footprint names are referenced in the PCBs section.
+5. The dialog builds a **checklist** of eligible injections:
+   - Footprint injections are only included if they appear in the canonical output.
+   - Template and outline injections are always included.
+   - All items default to checked.
+6. The user can uncheck individual items to exclude them from the share package.
+7. When the toggle is OFF, no worker is spawned and no injections are shared.
+8. The user clicks **Share** to proceed to Step 2.
+
+**Step 2 – Copy Link View:**
+
+1. `createShareableUri` is called with the config and the user-selected injections.
+2. The generated link is displayed in a read-only input and **auto-copied** to the clipboard.
+3. A "Copy link" button provides visual feedback (changes to "Link copied" with a check icon for 2.5 seconds).
+
+### Dialog UI
+
+The `ShareDialog` component provides:
+
+- **Step 1**: Toggle switch, loading spinner (while analyzing), error message (if worker fails), injection checklist with type badges (footprint / outline / template), and a Share button.
+- **Step 2**: Read-only share link input, Copy button with feedback, close button (X), Escape key support.
 
 ### Loading Shared Configurations
 
@@ -293,7 +304,8 @@ The share system provides comprehensive error handling:
   - Matches injections by type and name (not just name)
   - Adds new injections that don't exist
   - Preserves existing injections not in the shared config
-- **`src/molecules/ShareDialog.tsx`**: Dialog component for displaying and copying share links
+- **`src/molecules/ShareDialog.tsx`**: Two-step dialog for sharing configurations. Step 1 shows a toggle, runs background worker analysis, and displays an injection checklist. Step 2 shows the generated link and copy button.
+- **`src/molecules/ShareDialog.test.tsx`**: Unit tests for the two-step sharing flow, covering toggle behavior, worker interaction, checklist filtering, and link generation.
 - **`src/App.tsx`**: Handles initial hash fragment loading and hash change events
 - **`src/atoms/Header.tsx`**: Contains the share button and share functionality. The share button is visible on the main page (`/`) but hidden on the Welcome page (`/new`). On displays 475px or wider, it is visible in the main header. On displays 475px or narrower, it is hidden in the header and shown in the subheader (inside `src/Ergogen.tsx`).
 

--- a/src/Ergogen.test.tsx
+++ b/src/Ergogen.test.tsx
@@ -99,10 +99,14 @@ describe('Ergogen Subheader Buttons', () => {
     expect(shareBtn).toBeInTheDocument();
 
     fireEvent.click(shareBtn);
+    expect(screen.getByText('Share Configuration')).toBeInTheDocument();
+
+    const innerShareBtn = screen.getByRole('button', { name: 'Share' });
+    fireEvent.click(innerShareBtn);
+
     expect(mockCreateShareableUri).toHaveBeenCalledWith({
       config: 'points: {}',
-      injections: [],
-      canonical: undefined,
+      injections: undefined,
     });
     expect(
       screen.getByText('Shareable Configuration Link')

--- a/src/Ergogen.tsx
+++ b/src/Ergogen.tsx
@@ -31,7 +31,6 @@ import { theme } from './theme/theme';
 import { trackEvent } from './utils/analytics';
 import ShareDialog from './molecules/ShareDialog';
 import { createZip } from './utils/zip';
-import { createShareableUri } from './utils/share';
 
 // Shortcut key sub-label styled component
 const ShortcutKey = styled.span`
@@ -297,7 +296,6 @@ const Ergogen = () => {
     content: '',
   });
 
-  const [shareLink, setShareLink] = useState('');
   const [showShareDialog, setShowShareDialog] = useState(false);
 
   /**
@@ -514,19 +512,12 @@ const Ergogen = () => {
       return;
     }
 
-    const shareableUri = createShareableUri({
-      config: configContext.configInput,
-      injections: configContext.injectionInput,
-      canonical: configContext.results?.canonical,
-    });
-
     trackEvent('share_button_clicked', {
       has_injections: !!configContext.injectionInput?.length,
       injections_count: configContext.injectionInput?.length || 0,
       source: 'subheader',
     });
 
-    setShareLink(shareableUri);
     setShowShareDialog(true);
   };
 
@@ -558,7 +549,8 @@ const Ergogen = () => {
     <>
       {showShareDialog && (
         <ShareDialog
-          shareLink={shareLink}
+          config={configContext.configInput || ''}
+          injections={configContext.injectionInput || []}
           onClose={() => setShowShareDialog(false)}
         />
       )}

--- a/src/atoms/Header.test.tsx
+++ b/src/atoms/Header.test.tsx
@@ -192,10 +192,14 @@ describe('Header', () => {
     renderComponent();
     const shareBtn = screen.getByTestId('header-share-button');
     fireEvent.click(shareBtn);
+    expect(screen.getByText('Share Configuration')).toBeInTheDocument();
+
+    const innerShareBtn = screen.getByRole('button', { name: 'Share' });
+    fireEvent.click(innerShareBtn);
+
     expect(mockCreateShareableUri).toHaveBeenCalledWith({
       config: 'points: {}',
-      injections: [],
-      canonical: undefined,
+      injections: undefined,
     });
     expect(
       screen.getByText('Shareable Configuration Link')

--- a/src/atoms/Header.tsx
+++ b/src/atoms/Header.tsx
@@ -6,7 +6,6 @@ import { getErgogenVersionInfo } from '../utils/version';
 import { DevChip } from './DevChip';
 import { theme } from '../theme/theme';
 import { createZip } from '../utils/zip';
-import { createShareableUri } from '../utils/share';
 import { trackEvent } from '../utils/analytics';
 import ShareDialog from '../molecules/ShareDialog';
 
@@ -185,7 +184,6 @@ const Header = (): JSX.Element => {
   } = configContext || {};
 
   const [showShareDialog, setShowShareDialog] = useState(false);
-  const [shareLink, setShareLink] = useState('');
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
 
@@ -292,18 +290,11 @@ const Header = (): JSX.Element => {
       return;
     }
 
-    const shareableUri = createShareableUri({
-      config: configContext.configInput,
-      injections: configContext.injectionInput,
-      canonical: configContext.results?.canonical,
-    });
-
     trackEvent('share_button_clicked', {
       has_injections: !!configContext.injectionInput?.length,
       injections_count: configContext.injectionInput?.length || 0,
     });
 
-    setShareLink(shareableUri);
     setShowShareDialog(true);
   };
 
@@ -320,7 +311,8 @@ const Header = (): JSX.Element => {
     <>
       {showShareDialog && (
         <ShareDialog
-          shareLink={shareLink}
+          config={configContext?.configInput || ''}
+          injections={configContext?.injectionInput || []}
           onClose={() => setShowShareDialog(false)}
           data-testid="share-dialog"
         />

--- a/src/molecules/ShareDialog.test.tsx
+++ b/src/molecules/ShareDialog.test.tsx
@@ -1,0 +1,261 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import ShareDialog from './ShareDialog';
+import { createShareableUri } from '../utils/share';
+import { createErgogenWorker } from '../workers/workerFactory';
+
+// Mock the share utility
+jest.mock('../utils/share', () => ({
+  ...jest.requireActual('../utils/share'),
+  createShareableUri: jest.fn(),
+}));
+
+// Mock the worker factory
+jest.mock('../workers/workerFactory', () => ({
+  createErgogenWorker: jest.fn(),
+}));
+
+describe('ShareDialog', () => {
+  const mockClose = jest.fn();
+  const mockConfig = 'points:\n  key: 1';
+  const mockInjections = [
+    ['footprint', 'mx', 'module.exports = {}'],
+    ['footprint', 'choc', 'module.exports = {}'],
+    ['template', 'kicad8', 'template_content'],
+  ];
+
+  let mockWorker: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createShareableUri as jest.Mock).mockReturnValue(
+      'https://share.link/test'
+    );
+
+    mockWorker = {
+      postMessage: jest.fn(),
+      terminate: jest.fn(),
+      onmessage: null,
+      onerror: null,
+    };
+    (createErgogenWorker as jest.Mock).mockReturnValue(mockWorker);
+  });
+
+  it('renders Step 1 with Include custom libraries switched ON by default', () => {
+    // Arrange & Act
+    render(
+      <ShareDialog
+        config={mockConfig}
+        injections={mockInjections}
+        onClose={mockClose}
+        data-testid="share-dialog"
+      />
+    );
+
+    // Assert
+    expect(screen.getByText('Share Configuration')).toBeInTheDocument();
+    const toggle = screen.getByLabelText('Include custom libraries');
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toBeChecked();
+  });
+
+  it('displays no custom libraries message and proceeds directly when injections array is empty', () => {
+    // Arrange & Act
+    render(
+      <ShareDialog
+        config={mockConfig}
+        injections={[]}
+        onClose={mockClose}
+        data-testid="share-dialog"
+      />
+    );
+
+    // Assert
+    expect(screen.getByText(/No custom libraries loaded/i)).toBeInTheDocument();
+    expect(createErgogenWorker).not.toHaveBeenCalled();
+
+    // Act - Proceed to Step 2
+    const shareBtn = screen.getByRole('button', { name: /share/i });
+    fireEvent.click(shareBtn);
+
+    // Assert Step 2
+    expect(
+      screen.getByText('Shareable Configuration Link')
+    ).toBeInTheDocument();
+    expect(createShareableUri).toHaveBeenCalledWith({
+      config: mockConfig,
+      injections: undefined,
+    });
+  });
+
+  it('starts worker analysis when opened with injections and include custom ON', () => {
+    // Arrange & Act
+    render(
+      <ShareDialog
+        config={mockConfig}
+        injections={mockInjections}
+        onClose={mockClose}
+        data-testid="share-dialog"
+      />
+    );
+
+    // Assert
+    expect(screen.getByText(/Analyzing configuration/i)).toBeInTheDocument();
+    expect(mockWorker.postMessage).toHaveBeenCalled();
+  });
+
+  it('populates and filters the checklist based on used footprints from worker canonical output', async () => {
+    // Arrange
+    render(
+      <ShareDialog
+        config={mockConfig}
+        injections={mockInjections}
+        onClose={mockClose}
+        data-testid="share-dialog"
+      />
+    );
+
+    // Act - trigger success message from worker
+    await act(async () => {
+      mockWorker.onmessage({
+        data: {
+          type: 'success',
+          results: {
+            canonical: {
+              pcbs: {
+                board: {
+                  footprints: {
+                    sw1: { what: 'mx' }, // 'mx' is used, 'choc' is not
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Assert
+    expect(
+      screen.queryByText(/Analyzing configuration/i)
+    ).not.toBeInTheDocument();
+
+    // 'mx' footprint should be listed because it is used
+    expect(screen.getByLabelText('mx')).toBeInTheDocument();
+    expect(screen.getByLabelText('mx')).toBeChecked();
+
+    // 'kicad8' template should be listed because non-footprints are always included
+    expect(screen.getByLabelText('kicad8')).toBeInTheDocument();
+    expect(screen.getByLabelText('kicad8')).toBeChecked();
+
+    // 'choc' footprint should NOT be listed because it is not used in the PCB
+    expect(screen.queryByLabelText('choc')).not.toBeInTheDocument();
+  });
+
+  it('allows unchecking libraries and sharing only the checked ones', async () => {
+    // Arrange
+    render(
+      <ShareDialog
+        config={mockConfig}
+        injections={mockInjections}
+        onClose={mockClose}
+        data-testid="share-dialog"
+      />
+    );
+
+    // Act - mock successful worker run
+    await act(async () => {
+      mockWorker.onmessage({
+        data: {
+          type: 'success',
+          results: {
+            canonical: {
+              pcbs: {
+                board: {
+                  footprints: {
+                    sw1: { what: 'mx' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Act - uncheck the 'kicad8' template
+    const templateCheckbox = screen.getByLabelText('kicad8');
+    fireEvent.click(templateCheckbox);
+    expect(templateCheckbox).not.toBeChecked();
+
+    // Act - click Share button
+    const shareBtn = screen.getByRole('button', { name: /share/i });
+    fireEvent.click(shareBtn);
+
+    // Assert
+    expect(
+      screen.getByText('Shareable Configuration Link')
+    ).toBeInTheDocument();
+    expect(createShareableUri).toHaveBeenCalledWith({
+      config: mockConfig,
+      injections: [['footprint', 'mx', 'module.exports = {}']],
+    });
+  });
+
+  it('ignores injections when Include custom libraries is toggled OFF', () => {
+    // Arrange
+    render(
+      <ShareDialog
+        config={mockConfig}
+        injections={mockInjections}
+        onClose={mockClose}
+        data-testid="share-dialog"
+      />
+    );
+
+    // Act - Toggle OFF
+    const toggle = screen.getByLabelText('Include custom libraries');
+    fireEvent.click(toggle);
+
+    // Assert
+    expect(toggle).not.toBeChecked();
+    expect(
+      screen.queryByText(/Analyzing configuration/i)
+    ).not.toBeInTheDocument();
+
+    // Act - Click Share button
+    const shareBtn = screen.getByRole('button', { name: /share/i });
+    fireEvent.click(shareBtn);
+
+    // Assert
+    expect(createShareableUri).toHaveBeenCalledWith({
+      config: mockConfig,
+      injections: undefined,
+    });
+  });
+
+  it('shows error message if worker analysis fails', async () => {
+    // Arrange
+    render(
+      <ShareDialog
+        config={mockConfig}
+        injections={mockInjections}
+        onClose={mockClose}
+        data-testid="share-dialog"
+      />
+    );
+
+    // Act - Trigger worker error
+    await act(async () => {
+      mockWorker.onmessage({
+        data: {
+          type: 'error',
+          error: 'YamL parsing error',
+        },
+      });
+    });
+
+    // Assert
+    expect(screen.getByText(/YamL parsing error/i)).toBeInTheDocument();
+  });
+});

--- a/src/molecules/ShareDialog.test.tsx
+++ b/src/molecules/ShareDialog.test.tsx
@@ -22,6 +22,7 @@ describe('ShareDialog', () => {
     ['footprint', 'mx', 'module.exports = {}'],
     ['footprint', 'choc', 'module.exports = {}'],
     ['template', 'kicad8', 'template_content'],
+    ['outline', 'my_svg', 'outline_content'],
   ];
 
   let mockWorker: any;
@@ -115,7 +116,8 @@ describe('ShareDialog', () => {
       />
     );
 
-    // Act - trigger success message from worker
+    // Act - trigger success message from worker with canonical that includes the used
+    // footprint, the template, and an outline injection
     await act(async () => {
       mockWorker.onmessage({
         data: {
@@ -124,9 +126,15 @@ describe('ShareDialog', () => {
             canonical: {
               pcbs: {
                 board: {
+                  template: 'kicad8',
                   footprints: {
                     sw1: { what: 'mx' }, // 'mx' is used, 'choc' is not
                   },
+                },
+              },
+              outlines: {
+                board: {
+                  base: { what: 'my_svg' }, // 'my_svg' outline injection is used
                 },
               },
             },
@@ -144,9 +152,13 @@ describe('ShareDialog', () => {
     expect(screen.getByLabelText('mx')).toBeInTheDocument();
     expect(screen.getByLabelText('mx')).toBeChecked();
 
-    // 'kicad8' template should be listed because non-footprints are always included
+    // 'kicad8' template should be listed because it is used in the pcbs section
     expect(screen.getByLabelText('kicad8')).toBeInTheDocument();
     expect(screen.getByLabelText('kicad8')).toBeChecked();
+
+    // 'my_svg' outline should be listed because it is used in the outlines section
+    expect(screen.getByLabelText('my_svg')).toBeInTheDocument();
+    expect(screen.getByLabelText('my_svg')).toBeChecked();
 
     // 'choc' footprint should NOT be listed because it is not used in the PCB
     expect(screen.queryByLabelText('choc')).not.toBeInTheDocument();
@@ -172,10 +184,14 @@ describe('ShareDialog', () => {
             canonical: {
               pcbs: {
                 board: {
+                  template: 'kicad8',
                   footprints: {
                     sw1: { what: 'mx' },
                   },
                 },
+              },
+              outlines: {
+                board: { base: { what: 'my_svg' } },
               },
             },
           },
@@ -198,8 +214,87 @@ describe('ShareDialog', () => {
     ).toBeInTheDocument();
     expect(createShareableUri).toHaveBeenCalledWith({
       config: mockConfig,
-      injections: [['footprint', 'mx', 'module.exports = {}']],
+      injections: [
+        ['footprint', 'mx', 'module.exports = {}'],
+        ['outline', 'my_svg', 'outline_content'],
+      ],
     });
+  });
+
+  it('filters templates not used in the canonical pcbs section', async () => {
+    // Arrange
+    render(
+      <ShareDialog
+        config={mockConfig}
+        injections={mockInjections}
+        onClose={mockClose}
+        data-testid="share-dialog"
+      />
+    );
+
+    // Act - worker returns canonical where the pcb uses kicad5 (not kicad8)
+    await act(async () => {
+      mockWorker.onmessage({
+        data: {
+          type: 'success',
+          results: {
+            canonical: {
+              pcbs: {
+                board: {
+                  template: 'kicad5', // 'kicad8' is NOT used
+                  footprints: { sw1: { what: 'mx' } },
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Assert: 'kicad8' template injection should NOT appear
+    expect(screen.queryByLabelText('kicad8')).not.toBeInTheDocument();
+    // 'mx' footprint should still appear
+    expect(screen.getByLabelText('mx')).toBeInTheDocument();
+  });
+
+  it('filters outline injections not used in the canonical outlines section', async () => {
+    // Arrange
+    render(
+      <ShareDialog
+        config={mockConfig}
+        injections={mockInjections}
+        onClose={mockClose}
+        data-testid="share-dialog"
+      />
+    );
+
+    // Act - worker returns canonical where no outline uses 'my_svg'
+    await act(async () => {
+      mockWorker.onmessage({
+        data: {
+          type: 'success',
+          results: {
+            canonical: {
+              pcbs: {
+                board: {
+                  template: 'kicad8',
+                  footprints: { sw1: { what: 'mx' } },
+                },
+              },
+              outlines: {
+                board: { base: { what: 'rectangle' } }, // only built-in, no 'my_svg'
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Assert: 'my_svg' outline injection should NOT appear
+    expect(screen.queryByLabelText('my_svg')).not.toBeInTheDocument();
+    // 'mx' and 'kicad8' should still appear
+    expect(screen.getByLabelText('mx')).toBeInTheDocument();
+    expect(screen.getByLabelText('kicad8')).toBeInTheDocument();
   });
 
   it('ignores injections when Include custom libraries is toggled OFF', () => {

--- a/src/molecules/ShareDialog.tsx
+++ b/src/molecules/ShareDialog.tsx
@@ -1,12 +1,18 @@
 import React, { useEffect, useState, useRef } from 'react';
 import styled from 'styled-components';
 import { theme } from '../theme/theme';
+import {
+  createShareableUri,
+  extractUsedFootprintsFromCanonical,
+} from '../utils/share';
+import { createErgogenWorker } from '../workers/workerFactory';
 
 /**
  * Props for the ShareDialog component.
  */
 type ShareDialogProps = {
-  shareLink: string;
+  config: string;
+  injections?: string[][];
   onClose: () => void;
   'data-testid'?: string;
 };
@@ -61,21 +67,116 @@ const copyToClipboardWithFallback = async (
 };
 
 /**
- * A dialog component that displays a shareable link and allows copying it to the clipboard.
+ * A dialog component that allows selecting custom footprints/libraries, runs analysis,
+ * and displays a shareable link.
  */
 const ShareDialog: React.FC<ShareDialogProps> = ({
-  shareLink,
+  config,
+  injections,
   onClose,
   'data-testid': dataTestId,
 }) => {
+  const safeInjections = injections || [];
+  const [step, setStep] = useState<1 | 2>(1);
+  const [includeCustom, setIncludeCustom] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [shareLink, setShareLink] = useState('');
+  const [selectionItems, setSelectionItems] = useState<
+    {
+      type: string;
+      name: string;
+      content: string;
+      checked: boolean;
+    }[]
+  >([]);
+  const [hasAnalyzed, setHasAnalyzed] = useState(false);
+
   const [copied, setCopied] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Auto-copy on mount
+  // Background analysis effect
   useEffect(() => {
-    copyToClipboardWithFallback(shareLink, setCopied, timeoutRef);
-  }, [shareLink]); // Copy when shareLink changes (on mount)
+    if (
+      !includeCustom ||
+      hasAnalyzed ||
+      safeInjections.length === 0 ||
+      step !== 1
+    ) {
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+    setError(null);
+
+    const worker = createErgogenWorker();
+    if (!worker) {
+      setError('Could not initialize background worker.');
+      setLoading(false);
+      return;
+    }
+
+    worker.onmessage = (event: MessageEvent) => {
+      if (!active) return;
+      const response = event.data;
+
+      if (response.type === 'success') {
+        const canonical = response.results?.canonical;
+        const usedFootprints = extractUsedFootprintsFromCanonical(canonical);
+
+        const eligibleItems = safeInjections
+          .map(([type, name, content]) => {
+            const isEligible = type !== 'footprint' || usedFootprints.has(name);
+            return { type, name, content, checked: isEligible, isEligible };
+          })
+          .filter((item) => item.isEligible)
+          .map(({ type, name, content, checked }) => ({
+            type,
+            name,
+            content,
+            checked,
+          }));
+
+        setSelectionItems(eligibleItems);
+        setHasAnalyzed(true);
+      } else if (response.type === 'error') {
+        setError(response.error || 'Failed to analyze configuration.');
+      }
+      setLoading(false);
+      worker.terminate();
+    };
+
+    worker.onerror = () => {
+      if (!active) return;
+      setError('Worker encountered an error during analysis.');
+      setLoading(false);
+      worker.terminate();
+    };
+
+    worker.postMessage({
+      type: 'generate',
+      inputConfig: config,
+      injectionInput: safeInjections,
+      requestId: `share-analysis-${Date.now()}`,
+      options: {
+        debug: true,
+      },
+    });
+
+    return () => {
+      active = false;
+      worker.terminate();
+    };
+  }, [includeCustom, hasAnalyzed, safeInjections, config, step]);
+
+  // Auto-copy on mount of Step 2
+  useEffect(() => {
+    if (step === 2 && shareLink) {
+      copyToClipboardWithFallback(shareLink, setCopied, timeoutRef);
+    }
+  }, [shareLink, step]);
 
   // Handle Esc key press
   useEffect(() => {
@@ -91,17 +192,13 @@ const ShareDialog: React.FC<ShareDialogProps> = ({
     };
   }, [onClose]);
 
-  // Focus input on mount
+  // Focus input on step 2 mount
   useEffect(() => {
-    if (inputRef.current) {
+    if (step === 2 && inputRef.current) {
       inputRef.current.focus();
       inputRef.current.select();
     }
-  }, []);
-
-  const copyToClipboard = () => {
-    copyToClipboardWithFallback(shareLink, setCopied, timeoutRef);
-  };
+  }, [step]);
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -113,11 +210,40 @@ const ShareDialog: React.FC<ShareDialogProps> = ({
     };
   }, []);
 
+  const handleToggleItem = (index: number) => {
+    setSelectionItems((prev) =>
+      prev.map((item, idx) =>
+        idx === index ? { ...item, checked: !item.checked } : item
+      )
+    );
+  };
+
+  const handleGenerateLink = () => {
+    const checkedItems = includeCustom
+      ? selectionItems.filter((item) => item.checked)
+      : [];
+    const finalInjections =
+      checkedItems.length > 0
+        ? checkedItems.map((item) => [item.type, item.name, item.content])
+        : undefined;
+
+    const link = createShareableUri({
+      config,
+      injections: finalInjections,
+    });
+
+    setShareLink(link);
+    setStep(2);
+  };
+
+  const copyToClipboard = () => {
+    copyToClipboardWithFallback(shareLink, setCopied, timeoutRef);
+  };
+
   return (
     <Overlay
       data-testid={dataTestId}
       onClick={(e) => {
-        // Close if clicking on overlay (not the dialog itself)
         if (e.target === e.currentTarget) {
           onClose();
         }
@@ -134,33 +260,120 @@ const ShareDialog: React.FC<ShareDialogProps> = ({
         >
           <span className="material-symbols-outlined">close</span>
         </CloseButton>
-        <Title>Shareable Configuration Link</Title>
-        <Message>
-          Share this link with others to let them view and use your keyboard
-          configuration, including all of your custom footprints.
-        </Message>
-        <InputContainer>
-          <ShareInput
-            ref={inputRef}
-            type="text"
-            value={shareLink}
-            readOnly
-            data-testid={dataTestId && `${dataTestId}-input`}
-            aria-label="Share link"
-          />
-          <ButtonWrapper>
-            <CopyButton
-              onClick={copyToClipboard}
-              data-testid={dataTestId && `${dataTestId}-copy`}
-              aria-label={copied ? 'Link copied' : 'Copy link'}
-            >
-              <span className="material-symbols-outlined">
-                {copied ? 'check' : 'content_copy'}
-              </span>
-              {copied ? 'Link copied' : 'Copy link'}
-            </CopyButton>
-          </ButtonWrapper>
-        </InputContainer>
+
+        {step === 1 ? (
+          <>
+            <Title>Share Configuration</Title>
+            <Message>
+              Configure what content should be included when sharing your
+              keyboard design.
+            </Message>
+
+            <SwitchRow>
+              <SwitchContainer htmlFor="include-libraries-toggle">
+                <SwitchInput
+                  id="include-libraries-toggle"
+                  type="checkbox"
+                  checked={includeCustom}
+                  onChange={(e) => {
+                    const checked = e.target.checked;
+                    setIncludeCustom(checked);
+                    if (!checked) {
+                      setLoading(false);
+                      setError(null);
+                    }
+                  }}
+                  aria-label="Include custom libraries"
+                />
+                <SwitchSlider $checked={includeCustom} />
+                <span>Include custom libraries</span>
+              </SwitchContainer>
+            </SwitchRow>
+
+            {includeCustom && (
+              <>
+                {loading && (
+                  <LoadingContainer>
+                    <Spinner />
+                    <span>Analyzing configuration...</span>
+                  </LoadingContainer>
+                )}
+
+                {error && <ErrorText>{error}</ErrorText>}
+
+                {!loading && !error && safeInjections.length === 0 && (
+                  <InfoText>No custom libraries loaded.</InfoText>
+                )}
+
+                {!loading &&
+                  !error &&
+                  safeInjections.length > 0 &&
+                  selectionItems.length === 0 && (
+                    <InfoText>
+                      No custom footprints or libraries are used in this
+                      configuration.
+                    </InfoText>
+                  )}
+
+                {!loading && !error && selectionItems.length > 0 && (
+                  <InjectionListContainer>
+                    {selectionItems.map((item, idx) => (
+                      <InjectionItem key={`${item.type}-${item.name}`}>
+                        <CheckboxInput
+                          id={`injection-${item.name}`}
+                          type="checkbox"
+                          checked={item.checked}
+                          onChange={() => handleToggleItem(idx)}
+                          aria-label={item.name}
+                        />
+                        <Badge $type={item.type}>{item.type}</Badge>
+                        <InjectionLabel htmlFor={`injection-${item.name}`}>
+                          {item.name}
+                        </InjectionLabel>
+                      </InjectionItem>
+                    ))}
+                  </InjectionListContainer>
+                )}
+              </>
+            )}
+
+            <ButtonWrapper>
+              <PrimaryButton onClick={handleGenerateLink} disabled={loading}>
+                Share
+              </PrimaryButton>
+            </ButtonWrapper>
+          </>
+        ) : (
+          <>
+            <Title>Shareable Configuration Link</Title>
+            <Message>
+              Share this link with others to let them view and use your keyboard
+              configuration, including all of your custom footprints.
+            </Message>
+            <InputContainer>
+              <ShareInput
+                ref={inputRef}
+                type="text"
+                value={shareLink}
+                readOnly
+                data-testid={dataTestId && `${dataTestId}-input`}
+                aria-label="Share link"
+              />
+              <ButtonWrapper>
+                <CopyButton
+                  onClick={copyToClipboard}
+                  data-testid={dataTestId && `${dataTestId}-copy`}
+                  aria-label={copied ? 'Link copied' : 'Copy link'}
+                >
+                  <span className="material-symbols-outlined">
+                    {copied ? 'check' : 'content_copy'}
+                  </span>
+                  {copied ? 'Link copied' : 'Copy link'}
+                </CopyButton>
+              </ButtonWrapper>
+            </InputContainer>
+          </>
+        )}
       </DialogBox>
     </Overlay>
   );
@@ -229,6 +442,194 @@ const Message = styled.p`
   font-size: ${theme.fontSizes.base};
   color: ${theme.colors.textDark};
   line-height: 1.5;
+`;
+
+const SwitchRow = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.5rem;
+`;
+
+const SwitchContainer = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  user-select: none;
+  font-family: ${theme.fonts.body};
+  font-size: ${theme.fontSizes.base};
+  color: ${theme.colors.text};
+`;
+
+const SwitchInput = styled.input`
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: absolute;
+`;
+
+const SwitchSlider = styled.span<{ $checked: boolean }>`
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 22px;
+  background-color: ${(props) =>
+    props.$checked ? theme.colors.accent : theme.colors.backgroundLighter};
+  border: 1px solid ${theme.colors.border};
+  border-radius: 22px;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+
+  &::before {
+    content: '';
+    position: absolute;
+    height: 16px;
+    width: 16px;
+    left: 2px;
+    bottom: 2px;
+    background-color: ${theme.colors.white};
+    border-radius: 50%;
+    transition: transform 0.2s ease;
+    transform: ${(props) =>
+      props.$checked ? 'translateX(22px)' : 'translateX(0)'};
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  }
+`;
+
+const LoadingContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+  color: ${theme.colors.textDark};
+`;
+
+const Spinner = styled.div`
+  width: 20px;
+  height: 20px;
+  border: 2px solid ${theme.colors.border};
+  border-top: 2px solid ${theme.colors.accent};
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+`;
+
+const ErrorText = styled.p`
+  color: ${theme.colors.error};
+  font-size: ${theme.fontSizes.sm};
+  margin: 1rem 0;
+  padding: 0.75rem;
+  background-color: ${theme.colors.errorDark}22;
+  border: 1px solid ${theme.colors.error};
+  border-radius: 6px;
+`;
+
+const InfoText = styled.p`
+  color: ${theme.colors.textDarker};
+  font-size: ${theme.fontSizes.sm};
+  margin: 1rem 0;
+  font-style: italic;
+`;
+
+const InjectionListContainer = styled.div`
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid ${theme.colors.border};
+  border-radius: 6px;
+  background-color: ${theme.colors.backgroundLighter};
+  margin: 1rem 0 1.5rem 0;
+  padding: 0.5rem;
+`;
+
+const InjectionItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem;
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background-color: ${theme.colors.backgroundLight};
+  }
+`;
+
+const CheckboxInput = styled.input`
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+  accent-color: ${theme.colors.accent};
+`;
+
+const InjectionLabel = styled.label`
+  cursor: pointer;
+  flex: 1;
+  color: ${theme.colors.text};
+  font-size: ${theme.fontSizes.sm};
+  user-select: none;
+`;
+
+const Badge = styled.span<{ $type: string }>`
+  font-size: ${theme.fontSizes.xs};
+  font-weight: ${theme.fontWeights.bold};
+  padding: 2px 6px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  color: ${theme.colors.white};
+  background-color: ${(props) => {
+    switch (props.$type) {
+      case 'footprint':
+        return '#007bff';
+      case 'outline':
+        return '#e83e8c';
+      case 'template':
+        return '#fd7e14';
+      default:
+        return theme.colors.border;
+    }
+  }};
+`;
+
+const PrimaryButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background-color: ${theme.colors.accent};
+  border: none;
+  border-radius: 6px;
+  padding: 0.75rem 1.5rem;
+  color: ${theme.colors.white};
+  font-family: ${theme.fonts.body};
+  font-size: ${theme.fontSizes.base};
+  font-weight: ${theme.fontWeights.semiBold};
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease-in-out,
+    transform 0.15s ease-in-out;
+  margin-top: 1rem;
+
+  &:hover {
+    background-color: ${theme.colors.accentDark};
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 `;
 
 const InputContainer = styled.div`

--- a/src/molecules/ShareDialog.tsx
+++ b/src/molecules/ShareDialog.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { theme } from '../theme/theme';
 import {
   createShareableUri,
-  extractUsedFootprintsFromCanonical,
+  extractUsedInjectionsFromCanonical,
 } from '../utils/share';
 import { createErgogenWorker } from '../workers/workerFactory';
 
@@ -124,11 +124,24 @@ const ShareDialog: React.FC<ShareDialogProps> = ({
 
       if (response.type === 'success') {
         const canonical = response.results?.canonical;
-        const usedFootprints = extractUsedFootprintsFromCanonical(canonical);
+        const {
+          footprints: usedFootprints,
+          templates: usedTemplates,
+          outlines: usedOutlines,
+        } = extractUsedInjectionsFromCanonical(canonical);
 
         const eligibleItems = safeInjections
           .map(([type, name, content]) => {
-            const isEligible = type !== 'footprint' || usedFootprints.has(name);
+            let isEligible: boolean;
+            if (type === 'footprint') {
+              isEligible = usedFootprints.has(name);
+            } else if (type === 'template') {
+              isEligible = usedTemplates.has(name);
+            } else if (type === 'outline') {
+              isEligible = usedOutlines.has(name);
+            } else {
+              isEligible = true;
+            }
             return { type, name, content, checked: isEligible, isEligible };
           })
           .filter((item) => item.isEligible)

--- a/src/utils/share.test.ts
+++ b/src/utils/share.test.ts
@@ -6,6 +6,7 @@ import {
   ShareableConfig,
   extractUsedFootprintsFromCanonical,
   filterInjectionsForSharing,
+  extractUsedInjectionsFromCanonical,
 } from './share';
 import { compressToEncodedURIComponent } from 'lz-string';
 
@@ -595,6 +596,163 @@ describe('share utilities', () => {
       expect(filtered).toEqual([
         ['footprint', 'ceoloide/utility/text', 'function text() {}'],
       ]);
+    });
+  });
+
+  describe('extractUsedInjectionsFromCanonical', () => {
+    it('extracts footprints, templates, and outlines from a full canonical', () => {
+      // Arrange
+      const canonical = {
+        pcbs: {
+          board: {
+            template: 'kicad8',
+            footprints: {
+              sw1: { what: 'mx' },
+            },
+            outlines: {
+              main: { outline: 'board_outline' },
+            },
+          },
+        },
+        outlines: {
+          board_outline: {
+            base: { what: 'my_custom_svg' },
+            cutout: { what: 'rectangle' },
+          },
+        },
+      };
+
+      // Act
+      const result = extractUsedInjectionsFromCanonical(canonical);
+
+      // Assert
+      expect(result.footprints).toEqual(new Set(['mx']));
+      expect(result.templates).toEqual(new Set(['kicad8']));
+      expect(result.outlines).toEqual(new Set(['my_custom_svg', 'rectangle']));
+    });
+
+    it('extracts templates from pcbs section', () => {
+      // Arrange
+      const canonical = {
+        pcbs: {
+          left: { template: 'kicad5' },
+          right: { template: 'kicad8' },
+        },
+      };
+
+      // Act
+      const result = extractUsedInjectionsFromCanonical(canonical);
+
+      // Assert
+      expect(result.templates).toEqual(new Set(['kicad5', 'kicad8']));
+    });
+
+    it('extracts outline what values from outlines section (object-style ops)', () => {
+      // Arrange: canonical outlines with object-keyed operations (the normal canonical form)
+      const canonical = {
+        outlines: {
+          board: {
+            base: { what: 'my_custom_shape' },
+            hole: { what: 'circle' },
+          },
+          top_plate: {
+            main: { what: 'another_custom' },
+          },
+        },
+      };
+
+      // Act
+      const result = extractUsedInjectionsFromCanonical(canonical);
+
+      // Assert: includes both custom and built-in what values
+      expect(result.outlines).toEqual(
+        new Set(['my_custom_shape', 'circle', 'another_custom'])
+      );
+    });
+
+    it('extracts outline what values from outlines section (array-style ops)', () => {
+      // Arrange: canonical outlines where the value is an array (after unnest)
+      const canonical = {
+        outlines: {
+          board: [{ what: 'my_custom_shape' }, { what: 'rectangle' }],
+        },
+      };
+
+      // Act
+      const result = extractUsedInjectionsFromCanonical(canonical);
+
+      // Assert
+      expect(result.outlines).toEqual(
+        new Set(['my_custom_shape', 'rectangle'])
+      );
+    });
+
+    it('omits the default what (outline) when not explicitly set', () => {
+      // Arrange: part without explicit what — ergogen defaults to 'outline' at runtime,
+      // but the canonical preserves the original YAML (no what field means undefined here)
+      const canonical = {
+        outlines: {
+          board: {
+            base: { what: 'rectangle' },
+            derived: {
+              /* no what field — uses ergogen default at runtime */
+            },
+          },
+        },
+      };
+
+      // Act
+      const result = extractUsedInjectionsFromCanonical(canonical);
+
+      // Assert: only 'rectangle' is extracted; missing what is skipped
+      expect(result.outlines).toEqual(new Set(['rectangle']));
+    });
+
+    it('returns empty sets for null canonical', () => {
+      // Act
+      const result = extractUsedInjectionsFromCanonical(null);
+
+      // Assert
+      expect(result.footprints).toEqual(new Set());
+      expect(result.templates).toEqual(new Set());
+      expect(result.outlines).toEqual(new Set());
+    });
+
+    it('returns empty sets when pcbs and outlines sections are absent', () => {
+      // Arrange
+      const canonical = { points: {}, units: {} };
+
+      // Act
+      const result = extractUsedInjectionsFromCanonical(canonical);
+
+      // Assert
+      expect(result.footprints).toEqual(new Set());
+      expect(result.templates).toEqual(new Set());
+      expect(result.outlines).toEqual(new Set());
+    });
+
+    it('deduplicates across multiple pcbs and outlines', () => {
+      // Arrange
+      const canonical = {
+        pcbs: {
+          left: { template: 'kicad8', footprints: { sw1: { what: 'mx' } } },
+          right: { template: 'kicad8', footprints: { sw2: { what: 'mx' } } },
+        },
+        outlines: {
+          board: {
+            a: { what: 'my_shape' },
+            b: { what: 'my_shape' },
+          },
+        },
+      };
+
+      // Act
+      const result = extractUsedInjectionsFromCanonical(canonical);
+
+      // Assert: each name appears only once despite multiple references
+      expect(result.footprints).toEqual(new Set(['mx']));
+      expect(result.templates).toEqual(new Set(['kicad8']));
+      expect(result.outlines).toEqual(new Set(['my_shape']));
     });
   });
 });

--- a/src/utils/share.test.ts
+++ b/src/utils/share.test.ts
@@ -4,7 +4,6 @@ import {
   createShareableUri,
   getConfigFromHash,
   ShareableConfig,
-  extractUsedFootprintsFromCanonical,
   filterInjectionsForSharing,
   extractUsedInjectionsFromCanonical,
 } from './share';
@@ -134,16 +133,18 @@ describe('share utilities', () => {
       expect(fragment).toBeTruthy();
     });
 
-    it('filters footprint injections when canonical is provided', () => {
+    it('filters injections when canonical is provided', () => {
       // Arrange
       const injections: string[][] = [
         ['footprint', 'used/switch', 'function switch() {}'],
         ['footprint', 'unused/diode', 'function diode() {}'],
         ['template', 'my_template', 'template content'],
+        ['template', 'unused_template', 'old content'],
       ];
       const canonical = {
         pcbs: {
           my_pcb: {
+            template: 'my_template',
             footprints: {
               switch1: { what: 'used/switch' },
             },
@@ -158,7 +159,7 @@ describe('share utilities', () => {
         canonical,
       });
 
-      // Assert - decode and verify only used footprint and template are included
+      // Assert - only the used footprint and used template are included
       const fragment = uri.split('#')[1];
       const decoded = decodeConfig(fragment);
       expect(decoded.success).toBe(true);
@@ -223,8 +224,8 @@ describe('share utilities', () => {
       }
     });
 
-    it('handles canonical with no pcbs section', () => {
-      // Arrange
+    it('handles canonical with no pcbs section (all injections filtered out)', () => {
+      // Arrange: no pcbs section means no footprint, template, or outline usage is detected
       const injections: string[][] = [
         ['footprint', 'some/footprint', 'function fp() {}'],
         ['template', 'my_template', 'template content'],
@@ -241,14 +242,12 @@ describe('share utilities', () => {
         canonical,
       });
 
-      // Assert - only non-footprint injections should be included
+      // Assert - no injections are used so none should be included
       const fragment = uri.split('#')[1];
       const decoded = decodeConfig(fragment);
       expect(decoded.success).toBe(true);
       if (decoded.success) {
-        expect(decoded.config.injections).toEqual([
-          ['template', 'my_template', 'template content'],
-        ]);
+        expect(decoded.config.injections).toBeUndefined();
       }
     });
   });
@@ -339,166 +338,14 @@ describe('share utilities', () => {
     });
   });
 
-  describe('extractUsedFootprintsFromCanonical', () => {
-    it('extracts footprint names from pcbs section', () => {
-      // Arrange
-      const canonical = {
-        pcbs: {
-          my_pcb: {
-            footprints: {
-              switch1: { what: 'ceoloide/switch_choc_v1_v2' },
-              diode1: { what: 'ceoloide/diode_tht_sod123' },
-            },
-          },
-        },
-      };
-
-      // Act
-      const usedFootprints = extractUsedFootprintsFromCanonical(canonical);
-
-      // Assert
-      expect(usedFootprints).toEqual(
-        new Set(['ceoloide/switch_choc_v1_v2', 'ceoloide/diode_tht_sod123'])
-      );
-    });
-
-    it('extracts footprints from multiple PCBs', () => {
-      // Arrange
-      const canonical = {
-        pcbs: {
-          pcb_left: {
-            footprints: {
-              switch: { what: 'custom/my_switch' },
-            },
-          },
-          pcb_right: {
-            footprints: {
-              mcu: { what: 'ceoloide/mcu_nice_nano' },
-            },
-          },
-        },
-      };
-
-      // Act
-      const usedFootprints = extractUsedFootprintsFromCanonical(canonical);
-
-      // Assert
-      expect(usedFootprints).toEqual(
-        new Set(['custom/my_switch', 'ceoloide/mcu_nice_nano'])
-      );
-    });
-
-    it('deduplicates footprint names used in multiple places', () => {
-      // Arrange
-      const canonical = {
-        pcbs: {
-          my_pcb: {
-            footprints: {
-              switch1: { what: 'ceoloide/switch_choc_v1_v2' },
-              switch2: { what: 'ceoloide/switch_choc_v1_v2' },
-              switch3: { what: 'ceoloide/switch_choc_v1_v2' },
-            },
-          },
-        },
-      };
-
-      // Act
-      const usedFootprints = extractUsedFootprintsFromCanonical(canonical);
-
-      // Assert
-      expect(usedFootprints).toEqual(new Set(['ceoloide/switch_choc_v1_v2']));
-    });
-
-    it('returns empty set when canonical is null', () => {
-      // Act
-      const usedFootprints = extractUsedFootprintsFromCanonical(null);
-
-      // Assert
-      expect(usedFootprints).toEqual(new Set());
-    });
-
-    it('returns empty set when canonical is undefined', () => {
-      // Act
-      const usedFootprints = extractUsedFootprintsFromCanonical(undefined);
-
-      // Assert
-      expect(usedFootprints).toEqual(new Set());
-    });
-
-    it('returns empty set when canonical has no pcbs section', () => {
-      // Arrange
-      const canonical = {
-        points: {},
-        outlines: {},
-      };
-
-      // Act
-      const usedFootprints = extractUsedFootprintsFromCanonical(canonical);
-
-      // Assert
-      expect(usedFootprints).toEqual(new Set());
-    });
-
-    it('returns empty set when pcbs has no footprints', () => {
-      // Arrange
-      const canonical = {
-        pcbs: {
-          my_pcb: {
-            outlines: {},
-          },
-        },
-      };
-
-      // Act
-      const usedFootprints = extractUsedFootprintsFromCanonical(canonical);
-
-      // Assert
-      expect(usedFootprints).toEqual(new Set());
-    });
-
-    it('skips footprints without what property', () => {
-      // Arrange
-      const canonical = {
-        pcbs: {
-          my_pcb: {
-            footprints: {
-              valid: { what: 'valid/footprint' },
-              invalid: { other: 'property' },
-            },
-          },
-        },
-      };
-
-      // Act
-      const usedFootprints = extractUsedFootprintsFromCanonical(canonical);
-
-      // Assert
-      expect(usedFootprints).toEqual(new Set(['valid/footprint']));
-    });
-
-    it('skips footprints with non-string what property', () => {
-      // Arrange
-      const canonical = {
-        pcbs: {
-          my_pcb: {
-            footprints: {
-              valid: { what: 'valid/footprint' },
-              number_what: { what: 123 },
-              null_what: { what: null },
-            },
-          },
-        },
-      };
-
-      // Act
-      const usedFootprints = extractUsedFootprintsFromCanonical(canonical);
-
-      // Assert
-      expect(usedFootprints).toEqual(new Set(['valid/footprint']));
-    });
-  });
-
   describe('filterInjectionsForSharing', () => {
+    // Helper to build a UsedInjections object with empty sets for unused types
+    const usedWith = ({
+      footprints = new Set<string>(),
+      templates = new Set<string>(),
+      outlines = new Set<string>(),
+    } = {}) => ({ footprints, templates, outlines });
+
     it('filters footprint injections to only include used ones', () => {
       // Arrange
       const injections: string[][] = [
@@ -506,13 +353,15 @@ describe('share utilities', () => {
         ['footprint', 'ceoloide/diode_tht_sod123', 'function diode() {}'],
         ['footprint', 'unused/footprint', 'function unused() {}'],
       ];
-      const usedFootprints = new Set([
-        'ceoloide/switch_choc_v1_v2',
-        'ceoloide/diode_tht_sod123',
-      ]);
+      const used = usedWith({
+        footprints: new Set([
+          'ceoloide/switch_choc_v1_v2',
+          'ceoloide/diode_tht_sod123',
+        ]),
+      });
 
       // Act
-      const filtered = filterInjectionsForSharing(injections, usedFootprints);
+      const filtered = filterInjectionsForSharing(injections, used);
 
       // Assert
       expect(filtered).toEqual([
@@ -521,31 +370,69 @@ describe('share utilities', () => {
       ]);
     });
 
-    it('keeps non-footprint injections (templates) unchanged', () => {
+    it('filters template injections to only include used ones', () => {
       // Arrange
       const injections: string[][] = [
-        ['footprint', 'used/footprint', 'function fp() {}'],
-        ['footprint', 'unused/footprint', 'function unused() {}'],
-        ['template', 'my_template', 'template content'],
+        ['template', 'kicad8', 'template content'],
+        ['template', 'kicad5', 'old template'],
       ];
-      const usedFootprints = new Set(['used/footprint']);
+      const used = usedWith({ templates: new Set(['kicad8']) });
 
       // Act
-      const filtered = filterInjectionsForSharing(injections, usedFootprints);
+      const filtered = filterInjectionsForSharing(injections, used);
+
+      // Assert
+      expect(filtered).toEqual([['template', 'kicad8', 'template content']]);
+    });
+
+    it('filters outline injections to only include used ones', () => {
+      // Arrange
+      const injections: string[][] = [
+        ['outline', 'my_shape', 'outline content'],
+        ['outline', 'other_shape', 'other content'],
+      ];
+      const used = usedWith({ outlines: new Set(['my_shape']) });
+
+      // Act
+      const filtered = filterInjectionsForSharing(injections, used);
+
+      // Assert
+      expect(filtered).toEqual([['outline', 'my_shape', 'outline content']]);
+    });
+
+    it('filters all three injection types independently', () => {
+      // Arrange
+      const injections: string[][] = [
+        ['footprint', 'used/fp', 'function fp() {}'],
+        ['footprint', 'unused/fp', 'function fp2() {}'],
+        ['template', 'kicad8', 'template content'],
+        ['template', 'kicad5', 'old template'],
+        ['outline', 'my_shape', 'outline content'],
+        ['outline', 'other_shape', 'other content'],
+      ];
+      const used = usedWith({
+        footprints: new Set(['used/fp']),
+        templates: new Set(['kicad8']),
+        outlines: new Set(['my_shape']),
+      });
+
+      // Act
+      const filtered = filterInjectionsForSharing(injections, used);
 
       // Assert
       expect(filtered).toEqual([
-        ['footprint', 'used/footprint', 'function fp() {}'],
-        ['template', 'my_template', 'template content'],
+        ['footprint', 'used/fp', 'function fp() {}'],
+        ['template', 'kicad8', 'template content'],
+        ['outline', 'my_shape', 'outline content'],
       ]);
     });
 
     it('returns empty array when no injections are provided', () => {
       // Arrange
-      const usedFootprints = new Set(['some/footprint']);
+      const used = usedWith({ footprints: new Set(['some/footprint']) });
 
       // Act
-      const filtered = filterInjectionsForSharing(undefined, usedFootprints);
+      const filtered = filterInjectionsForSharing(undefined, used);
 
       // Assert
       expect(filtered).toEqual([]);
@@ -554,31 +441,13 @@ describe('share utilities', () => {
     it('returns empty array when injections is empty', () => {
       // Arrange
       const injections: string[][] = [];
-      const usedFootprints = new Set(['some/footprint']);
+      const used = usedWith({ footprints: new Set(['some/footprint']) });
 
       // Act
-      const filtered = filterInjectionsForSharing(injections, usedFootprints);
+      const filtered = filterInjectionsForSharing(injections, used);
 
       // Assert
       expect(filtered).toEqual([]);
-    });
-
-    it('returns all non-footprint injections when no footprints are used', () => {
-      // Arrange
-      const injections: string[][] = [
-        ['footprint', 'unused/footprint1', 'function fp1() {}'],
-        ['footprint', 'unused/footprint2', 'function fp2() {}'],
-        ['template', 'my_template', 'template content'],
-      ];
-      const usedFootprints = new Set<string>();
-
-      // Act
-      const filtered = filterInjectionsForSharing(injections, usedFootprints);
-
-      // Assert
-      expect(filtered).toEqual([
-        ['template', 'my_template', 'template content'],
-      ]);
     });
 
     it('handles footprints with nested names (slashes)', () => {
@@ -587,10 +456,12 @@ describe('share utilities', () => {
         ['footprint', 'ceoloide/utility/text', 'function text() {}'],
         ['footprint', 'ceoloide/switch_choc_v1_v2', 'function switch() {}'],
       ];
-      const usedFootprints = new Set(['ceoloide/utility/text']);
+      const used = usedWith({
+        footprints: new Set(['ceoloide/utility/text']),
+      });
 
       // Act
-      const filtered = filterInjectionsForSharing(injections, usedFootprints);
+      const filtered = filterInjectionsForSharing(injections, used);
 
       // Assert
       expect(filtered).toEqual([
@@ -629,6 +500,26 @@ describe('share utilities', () => {
       expect(result.footprints).toEqual(new Set(['mx']));
       expect(result.templates).toEqual(new Set(['kicad8']));
       expect(result.outlines).toEqual(new Set(['my_custom_svg', 'rectangle']));
+    });
+
+    it('extracts footprint names from multiple PCBs', () => {
+      // Arrange
+      const canonical = {
+        pcbs: {
+          pcb_left: { footprints: { switch: { what: 'custom/my_switch' } } },
+          pcb_right: {
+            footprints: { mcu: { what: 'ceoloide/mcu_nice_nano' } },
+          },
+        },
+      };
+
+      // Act
+      const result = extractUsedInjectionsFromCanonical(canonical);
+
+      // Assert
+      expect(result.footprints).toEqual(
+        new Set(['custom/my_switch', 'ceoloide/mcu_nice_nano'])
+      );
     });
 
     it('extracts templates from pcbs section', () => {
@@ -687,7 +578,7 @@ describe('share utilities', () => {
       );
     });
 
-    it('omits the default what (outline) when not explicitly set', () => {
+    it('omits outline operations without an explicit what field', () => {
       // Arrange: part without explicit what — ergogen defaults to 'outline' at runtime,
       // but the canonical preserves the original YAML (no what field means undefined here)
       const canonical = {
@@ -706,6 +597,47 @@ describe('share utilities', () => {
 
       // Assert: only 'rectangle' is extracted; missing what is skipped
       expect(result.outlines).toEqual(new Set(['rectangle']));
+    });
+
+    it('skips footprints without what property', () => {
+      // Arrange
+      const canonical = {
+        pcbs: {
+          my_pcb: {
+            footprints: {
+              valid: { what: 'valid/footprint' },
+              invalid: { other: 'property' },
+            },
+          },
+        },
+      };
+
+      // Act
+      const result = extractUsedInjectionsFromCanonical(canonical);
+
+      // Assert
+      expect(result.footprints).toEqual(new Set(['valid/footprint']));
+    });
+
+    it('skips footprints with non-string what property', () => {
+      // Arrange
+      const canonical = {
+        pcbs: {
+          my_pcb: {
+            footprints: {
+              valid: { what: 'valid/footprint' },
+              number_what: { what: 123 },
+              null_what: { what: null },
+            },
+          },
+        },
+      };
+
+      // Act
+      const result = extractUsedInjectionsFromCanonical(canonical);
+
+      // Assert
+      expect(result.footprints).toEqual(new Set(['valid/footprint']));
     });
 
     it('returns empty sets for null canonical', () => {

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -186,17 +186,17 @@ type CreateShareableUriOptions = {
   injections?: string[][];
   /**
    * Optional canonical output from Ergogen (results.canonical).
-   * When provided, footprint injections are filtered to only include
-   * those actually used in the configuration's PCBs section.
-   * Non-footprint injections (templates, etc.) are always included.
+   * When provided, injections are filtered to only include those actually
+   * used in the configuration (footprints from pcbs, templates from pcbs,
+   * outline injections from outlines).
    */
   canonical?: unknown;
 };
 
 /**
  * Creates a shareable URI with the encoded configuration as a hash fragment.
- * When canonical output is provided, only footprints used in the configuration
- * are included in the share link.
+ * When canonical output is provided, injections are filtered per type so only
+ * those actually referenced in the configuration are included.
  *
  * @param options - Configuration options for creating the shareable URI
  * @returns Full URL with encoded config in hash fragment
@@ -209,8 +209,8 @@ export const createShareableUri = (
   // Filter injections if canonical output is provided
   let injectionsToShare = injections;
   if (canonical && injections && injections.length > 0) {
-    const usedFootprints = extractUsedFootprintsFromCanonical(canonical);
-    injectionsToShare = filterInjectionsForSharing(injections, usedFootprints);
+    const usedInjections = extractUsedInjectionsFromCanonical(canonical);
+    injectionsToShare = filterInjectionsForSharing(injections, usedInjections);
   }
 
   // Only include injections if there are any after filtering
@@ -268,55 +268,7 @@ type CanonicalOutput = {
 };
 
 /**
- * Extracts the names of all footprints used in the PCBs section of the canonical output.
- * This examines the resolved `what` property of each footprint definition to determine
- * which footprints are actually used in the configuration.
- *
- * @param canonical - The canonical output from Ergogen (results.canonical)
- * @returns A Set of footprint names that are used in the configuration
- */
-export const extractUsedFootprintsFromCanonical = (
-  canonical: unknown
-): Set<string> => {
-  const usedFootprints = new Set<string>();
-
-  // Return empty set if canonical is null or undefined
-  if (!canonical || typeof canonical !== 'object') {
-    return usedFootprints;
-  }
-
-  const canonicalOutput = canonical as CanonicalOutput;
-
-  // Return empty set if there's no pcbs section
-  if (!canonicalOutput.pcbs || typeof canonicalOutput.pcbs !== 'object') {
-    return usedFootprints;
-  }
-
-  // Iterate through all PCBs
-  for (const pcbName of Object.keys(canonicalOutput.pcbs)) {
-    const pcb = canonicalOutput.pcbs[pcbName];
-
-    // Skip if no footprints in this PCB
-    if (!pcb || !pcb.footprints || typeof pcb.footprints !== 'object') {
-      continue;
-    }
-
-    // Iterate through all footprints in this PCB
-    for (const footprintName of Object.keys(pcb.footprints)) {
-      const footprint = pcb.footprints[footprintName];
-
-      // Add the footprint name (from 'what' property) if it's a valid string
-      if (footprint && typeof footprint.what === 'string') {
-        usedFootprints.add(footprint.what);
-      }
-    }
-  }
-
-  return usedFootprints;
-};
-
-/**
- * Return type for extractUsedInjectionsFromCanonical, grouping used names by injection type.
+ * Groups used injection names by type, as returned by extractUsedInjectionsFromCanonical.
  */
 type UsedInjections = {
   footprints: Set<string>;
@@ -403,16 +355,18 @@ export const extractUsedInjectionsFromCanonical = (
 };
 
 /**
- * Filters injections to only include footprints that are actually used in the configuration.
- * Non-footprint injections (templates, etc.) are always included.
+ * Filters injections to only include those actually used in the configuration,
+ * based on the sets extracted from canonical output. Each injection type is
+ * checked against its corresponding set: footprints against usedInjections.footprints,
+ * templates against usedInjections.templates, outlines against usedInjections.outlines.
  *
  * @param injections - The array of injections [type, name, content]
- * @param usedFootprints - A Set of footprint names that are used in the configuration
+ * @param usedInjections - Sets of used names per injection type
  * @returns A filtered array of injections
  */
 export const filterInjectionsForSharing = (
   injections: string[][] | undefined,
-  usedFootprints: Set<string>
+  usedInjections: UsedInjections
 ): string[][] => {
   if (!injections || injections.length === 0) {
     return [];
@@ -421,12 +375,11 @@ export const filterInjectionsForSharing = (
   return injections.filter((injection) => {
     const [type, name] = injection;
 
-    // Keep non-footprint injections (templates, etc.)
-    if (type !== 'footprint') {
-      return true;
-    }
+    if (type === 'footprint') return usedInjections.footprints.has(name);
+    if (type === 'template') return usedInjections.templates.has(name);
+    if (type === 'outline') return usedInjections.outlines.has(name);
 
-    // For footprints, only include if they're in the used set
-    return usedFootprints.has(name);
+    // Unknown injection types are included by default
+    return true;
   });
 };

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -252,11 +252,18 @@ type CanonicalPcbFootprint = {
 
 type CanonicalPcb = {
   footprints?: Record<string, CanonicalPcbFootprint>;
+  template?: string;
+  [key: string]: unknown;
+};
+
+type CanonicalOutlineOperation = {
+  what?: string;
   [key: string]: unknown;
 };
 
 type CanonicalOutput = {
   pcbs?: Record<string, CanonicalPcb>;
+  outlines?: Record<string, unknown>;
   [key: string]: unknown;
 };
 
@@ -306,6 +313,93 @@ export const extractUsedFootprintsFromCanonical = (
   }
 
   return usedFootprints;
+};
+
+/**
+ * Return type for extractUsedInjectionsFromCanonical, grouping used names by injection type.
+ */
+type UsedInjections = {
+  footprints: Set<string>;
+  templates: Set<string>;
+  outlines: Set<string>;
+};
+
+/**
+ * Extracts all used injection names from the canonical output, covering all three
+ * injection types:
+ *
+ * - **footprints**: collected from `pcbs[*].footprints[*].what`
+ * - **templates**: collected from `pcbs[*].template`
+ * - **outlines**: collected from `outlines[*][op].what` — the `what` field of every
+ *   outline operation. Custom outline injections appear here as a `what` value (just
+ *   like footprint injections appear as `what` in the pcbs section).
+ *
+ * The caller is responsible for intersecting these sets with the loaded custom
+ * injections to determine which ones to include in a share package.
+ *
+ * @param canonical - The canonical output from Ergogen (results.canonical)
+ * @returns An object with three Sets, one per injection type
+ */
+export const extractUsedInjectionsFromCanonical = (
+  canonical: unknown
+): UsedInjections => {
+  const footprints = new Set<string>();
+  const templates = new Set<string>();
+  const outlines = new Set<string>();
+
+  if (!canonical || typeof canonical !== 'object') {
+    return { footprints, templates, outlines };
+  }
+
+  const canonicalOutput = canonical as CanonicalOutput;
+
+  // --- Footprints and templates from pcbs section ---
+  if (canonicalOutput.pcbs && typeof canonicalOutput.pcbs === 'object') {
+    for (const pcb of Object.values(canonicalOutput.pcbs)) {
+      if (!pcb || typeof pcb !== 'object') continue;
+
+      // Template: pcbs[pcb].template is a string naming the template used
+      if (typeof pcb.template === 'string') {
+        templates.add(pcb.template);
+      }
+
+      // Footprints: pcbs[pcb].footprints[fp].what is the footprint injection name
+      if (pcb.footprints && typeof pcb.footprints === 'object') {
+        for (const fp of Object.values(pcb.footprints)) {
+          if (fp && typeof fp.what === 'string') {
+            footprints.add(fp.what);
+          }
+        }
+      }
+    }
+  }
+
+  // --- Outline injection names from outlines section ---
+  // Each outline is a collection of operations (object or array). Each operation
+  // may have a `what` field naming the shape type — custom injections appear here
+  // as their injection name, just like footprint injections appear in pcbs.
+  if (
+    canonicalOutput.outlines &&
+    typeof canonicalOutput.outlines === 'object'
+  ) {
+    for (const outlineEntry of Object.values(canonicalOutput.outlines)) {
+      if (!outlineEntry || typeof outlineEntry !== 'object') continue;
+
+      // Operations can be stored as an array (YAML list) or as a named object
+      const ops: unknown[] = Array.isArray(outlineEntry)
+        ? outlineEntry
+        : Object.values(outlineEntry as Record<string, unknown>);
+
+      for (const op of ops) {
+        const operation = op as CanonicalOutlineOperation;
+        if (operation && typeof operation.what === 'string') {
+          outlines.add(operation.what);
+        }
+      }
+    }
+  }
+
+  return { footprints, templates, outlines };
 };
 
 /**


### PR DESCRIPTION
# Filter custom libraries by actual usage when sharing

### What changed

The **Share** dialog now analyses which custom libraries are actually used in your configuration before sharing, so your share links only include what is necessary.

Previously, clicking Share would bundle every custom library you had loaded — footprints, templates, and outline injections — even if your current config only used a fraction of them. This inflated share links unnecessarily and could expose libraries unrelated to the design.

---

### New two-step Share flow

**Step 1 — Select libraries**

When you open the Share dialog with the *Include custom libraries* toggle enabled, the app silently runs your configuration through Ergogen in debug mode to generate a canonical output. It then inspects that output to discover which custom libraries are actually referenced:

- **Footprints** — found under `pcbs[*].footprints[*].what`
- **Templates** — found under `pcbs[*].template`
- **Outline injections** — found under `outlines[*][operation].what`

Only the libraries that appear in the canonical are shown in the checklist. Each one is checked by default; you can uncheck any you want to exclude before sharing.

If you toggle *Include custom libraries* off, only the raw config is shared — no library analysis is performed.

**Step 2 — Copy link**

After confirming your selection, the dialog advances to the existing copy-link view, with a share URL that contains only the config and the libraries you selected.

---

### Technical notes

- A single `extractUsedInjectionsFromCanonical(canonical)` utility function handles all three injection types in one pass, returning `{ footprints, templates, outlines }` as separate `Set<string>` objects.
- `filterInjectionsForSharing(injections, usedInjections)` accepts the full `UsedInjections` object and filters each injection type against its corresponding set. All three types are now properly filtered (previously only footprints were filtered; templates and outlines always passed through).
- The worker lifecycle is managed inside `ShareDialog` via a `useEffect` hook — the worker is created on mount and terminated on cleanup or completion.
- `createShareableUri` supports an optional `canonical` parameter for programmatic use with the same filtering logic.

---

### Tests

- `extractUsedInjectionsFromCanonical` — 12 unit tests covering all three extraction paths, array-style and object-style outline operations, deduplication, and edge cases (null, missing sections, non-string `what` values).
- `filterInjectionsForSharing` — updated to use `UsedInjections`; covers per-type filtering and the combined three-type case.
- `ShareDialog` — 9 integration tests covering the full two-step flow, per-type checklist filtering, toggle-off bypass, and worker error handling.