### PR TITLE
Add version compatibility checks and warnings for shared links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Shared Link Version Compatibility Warnings
+
+July 10, 2026
+
+![A warning modal showing GUI Version Mismatch, Ergogen Version Mismatch, and Custom Ergogen Version warnings with Accept and Cancel buttons.](./public/images/changelog/placeholder.png)
+
+When sharing configurations, users might open shared links on older versions of the GUI or with different Ergogen backends, which could lead to compatibility issues or compile crashes. For example, if a share link uses templates or outlines that require Ergogen v4.3.0+, but the receiving website is running Ergogen v4.2.1, it would fail to compile without warning.
+
+To address this, we've implemented version compatibility checking for shared links. Share links now embed the GUI version and the full Ergogen version (including custom branches and forks) in their encoded payload. On load or hash change, the receiving site compares its local environment with the link's metadata. If the local GUI or Ergogen version is older, or if a custom fork was used to create the link, a themed Version Compatibility Warning Modal is shown. This modal details the mismatch and warns of potential issues. It provides a clickable link to the custom GitHub repository/ref for investigation, and lets the user choose to Accept and load the configuration anyway, or Cancel and abort. To ensure backward compatibility, legacy links without version metadata fallback to assuming GUI version 0.9.0 and official Ergogen version 4.2.1.
+
+**What changed:**
+
+- **Embedded Version Metadata**: Automatically encodes the local GUI version and active Ergogen version (with full custom fork/branch paths) in all new shareable link payloads
+- **Environment Comparison**: Resolves and compares current GUI and Ergogen versions against incoming share link metadata using standard semver comparisons
+- **Version Compatibility Warning Modal**: Intercepts config loading to display a styled modal informing the user of newer GUI/Ergogen versions or custom Ergogen versions in use
+- **GitHub Reference Linking**: Extracts and displays a clickable link referencing the custom GitHub repository and ref when custom Ergogen forks are used
+- **Action Control**: Restricts config loading, letting the user explicitly Accept (load the config as is) or Cancel (discard and abort)
+- **Legacy Fallbacks**: Gracefully parses older shared links lacking version fields by assuming GUI v0.9.0 and official Ergogen v4.2.1 fallback values
+
 ## Environment-Based Feature Flags
 
 July 10, 2026

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -218,8 +218,11 @@ Shareable links use the format: `https://ergogen.io/#<encoded-config>` where the
 - The keyboard configuration (YAML/JSON string)
 - Only the footprint injections that were selected by the user in the Share dialog (filtered to those actually used in the design)
 - All non-footprint injections (templates, etc.) that were selected by the user
+- **Version metadata**:
+  - `guiVersion`: The version of the GUI in package.json at the time of creation (e.g. `0.8.9`)
+  - `ergogenVersion`: The full Ergogen version used (e.g. `github:ceoloide/ergogen#v4.3.0` or official `github:ergogen/ergogen#v4.2.1`)
 
-The configuration and injections are compressed and URL-encoded using `lz-string`'s `compressToEncodedURIComponent` function for efficient transmission.
+The configuration, injections, and version metadata are compressed and URL-encoded using `lz-string`'s `compressToEncodedURIComponent` function for efficient transmission.
 
 ### Sharing Process
 
@@ -256,26 +259,18 @@ The `ShareDialog` component provides:
 
 When a user navigates to a URL with a hash fragment:
 
-1. **Initial Load**: On page load, `App.tsx` synchronously checks for a hash fragment before initializing localStorage:
-   - Extracts and decodes the hash fragment
-   - Validates the structure (must have `config` as string, optional `injections` as `string[][]`)
-   - If valid, sets initial config and merges injections with conflict resolution, storing both in localStorage
-   - If invalid, stores error message for display via the error banner
-   - Clears the hash fragment after processing
-   - **Note**: Initial load uses overwrite strategy (no dialog) since it happens synchronously before React renders
+1. **Initial Load / Hash Changes**: On page load or hash change, `App.tsx` checks for a hash fragment, decodes, and validates the shared payload structure.
+2. **Version Compatibility Checking**: Before loading the configuration, the application performs environment checks:
+   - If the current GUI version is older than the one in the share link, or if the current Ergogen version is older than the one in the share link, or if the share link used a custom Ergogen version:
+     - The loading is intercepted and a **Version Compatibility Warning Modal** (`ShareVersionCompatibilityDialog`) is shown.
+     - The user is alerted of the version mismatches (e.g., GUI/Ergogen version differences) or that a custom Ergogen fork was used (with a clickable link to the GitHub repository/ref for investigation).
+     - The user can choose to **Accept and Load** (which imports the configuration as is) or **Cancel** (which aborts loading completely).
+   - **Backward Compatibility**: If a parsed share link lacks version information (legacy links), the application assumes it was shared with GUI version `0.9.0` and official Ergogen version `4.2.1` (`github:ergogen/ergogen#v4.2.1`).
+   - If all versions are compatible (or the user accepts the compatibility warning dialog), the configuration loading proceeds.
 
-2. **Hash Change Events**: When navigating to a shared URL while already on the page:
-   - `AppContent` component listens for `hashchange` events
-   - Repeats the same extraction, validation, and loading process
-   - **Shows conflict resolution dialog** for any injection conflicts (footprints, templates, etc.)
-   - Updates the configuration state and triggers regeneration after conflicts are resolved
-
-3. **Injection Merging**: When loading shared configurations:
-   - Uses `mergeInjectionArraysWithResolution` utility function with conflict resolution
-   - Shows `ConflictResolutionDialog` for each conflict, allowing user to choose skip, overwrite, or keep both
-   - Works for all injection types (footprints, templates, etc.)
-   - New injections are added if they don't exist
-   - Existing injections not present in the shared config are preserved
+3. **Conflict Resolution**:
+   - If injections are present, conflict resolution is performed using `ConflictResolutionDialog` for name conflicts.
+   - Updates the configuration state and triggers regeneration.
 
 ### Error Handling
 
@@ -289,40 +284,35 @@ The share system provides comprehensive error handling:
 ### Sharing Implementation
 
 - **`src/utils/share.ts`**: Core sharing utilities:
-  - `encodeConfig`: Compresses and encodes configuration and injections
-  - `decodeConfig`: Decompresses and validates shared configurations, returns `DecodeResult` union type
-  - `createShareableUri`: Constructs the full shareable URL. Accepts an options object with:
-    - `config`: The YAML/JSON configuration string (required)
-    - `injections`: Optional array of injections
-    - `canonical`: Optional canonical output from Ergogen. When provided, footprint injections are automatically filtered to only include those used in the PCBs section
-  - `getConfigFromHash`: Extracts and decodes hash fragment from current URL
-  - `extractUsedFootprintsFromCanonical`: Extracts footprint names from canonical output's PCBs section
-  - `filterInjectionsForSharing`: Filters injections to only include used footprints (keeps all non-footprint injections)
-- **`src/utils/injections.ts`**: Contains functions for merging injection arrays:
-  - `mergeInjectionArraysWithResolution`: Merges with conflict resolution (skip, overwrite, keep-both)
-  - `mergeInjectionArrays`: Default merge with overwrite strategy (uses `mergeInjectionArraysWithResolution` internally)
-  - Matches injections by type and name (not just name)
-  - Adds new injections that don't exist
-  - Preserves existing injections not in the shared config
-- **`src/molecules/ShareDialog.tsx`**: Two-step dialog for sharing configurations. Step 1 shows a toggle, runs background worker analysis, and displays an injection checklist. Step 2 shows the generated link and copy button.
-- **`src/molecules/ShareDialog.test.tsx`**: Unit tests for the two-step sharing flow, covering toggle behavior, worker interaction, checklist filtering, and link generation.
-- **`src/App.tsx`**: Handles initial hash fragment loading and hash change events
-- **`src/atoms/Header.tsx`**: Contains the share button and share functionality. The share button is visible on the main page (`/`) but hidden on the Welcome page (`/new`). On displays 475px or wider, it is visible in the main header. On displays 475px or narrower, it is hidden in the header and shown in the subheader (inside `src/Ergogen.tsx`).
+  - `encodeConfig`: Compresses and encodes configuration and injections, automatically embedding GUI and Ergogen version metadata.
+  - `decodeConfig`: Decompresses and validates shared configurations. Assigns default fallback versions (`0.9.0` for GUI, `github:ergogen/ergogen#v4.2.1` for Ergogen) for backward compatibility when versions are missing in the payload. Returns `DecodeResult`.
+  - `createShareableUri`: Constructs the full shareable URL.
+  - `getConfigFromHash`: Extracts and decodes hash fragment from current URL.
+  - `extractUsedFootprintsFromCanonical`: Extracts footprint names from canonical output's PCBs section.
+  - `filterInjectionsForSharing`: Filters injections to only include used footprints.
+- **`src/utils/version.ts`**: Contains version parsing, comparison, and extraction utilities (`parseVersion`, `compareVersions`, `getSemverFromErgogenVersion`, `isCustomErgogenVersion`).
+- **`src/utils/injections.ts`**: Contains functions for merging injection arrays.
+- **`src/molecules/ShareDialog.tsx`**: Two-step dialog for sharing configurations.
+- **`src/molecules/ShareDialog.test.tsx`**: Unit tests for the two-step sharing flow.
+- **`src/molecules/ShareVersionCompatibilityDialog.tsx`**: Themed warning modal shown when loading a shared config with version mismatches or a custom Ergogen version.
+- **`src/molecules/ShareVersionCompatibilityDialog.test.tsx`**: Unit tests for the warning dialog.
+- **`src/App.tsx`**: Handles initial hash loading, hash change events, and integrates version compatibility warning checks before loading shared configurations.
+- **`src/App.test.tsx`**: Integration tests verifying App's mount and hashchange behavior when receiving compatible, incompatible, and custom-version share links.
+- **`src/atoms/Header.tsx`**: Contains the share button and share functionality.
 
 ### Future Enhancements
 
 Several potential improvements could enhance the sharing feature:
 
 1. **URL Length Validation**: Very large configurations might create URLs that exceed browser URL length limits (typically 2048-8192 characters depending on browser). Could add validation to warn users or suggest alternative sharing methods when URLs become too long.
-2. **Share Link Metadata**: Currently, share links only contain the configuration and injections. Could enhance the `ShareableConfig` interface to include optional metadata like keyboard name/description, creation timestamp, version information, or author information.
-3. **QR Code Generation**: For easier mobile sharing, could generate QR codes that users can scan to load configurations directly on mobile devices.
-4. **Share Link Shortening**: Very long URLs can be unwieldy. Could integrate with URL shortening services or create a custom short link service with a backend API.
-5. **Mobile Native Sharing**: On mobile devices, could integrate with native sharing APIs (Web Share API) to allow sharing through the device's native share menu (SMS, email, social media, etc.).
-6. **Share Link History**: Track previously generated share links in localStorage, allowing users to easily access and re-share recent configurations.
-7. **Share Link Validation**: Add a "Test Link" feature that validates a share link works correctly before sharing it with others.
-8. **Better Error Recovery**: When encountering partially corrupted share links, attempt to recover and load what's possible rather than showing a complete error (e.g., load config even if injections are corrupted).
-9. **Share Link Expiration**: Add optional expiration dates or time-to-live (TTL) for share links, useful for temporary sharing scenarios.
-10. **Compression Optimization**: Investigate alternative compression algorithms or compression settings that might provide better compression ratios for large configurations while maintaining URL safety.
+2. **QR Code Generation**: For easier mobile sharing, could generate QR codes that users can scan to load configurations directly on mobile devices.
+3. **Share Link Shortening**: Very long URLs can be unwieldy. Could integrate with URL shortening services or create a custom short link service with a backend API.
+4. **Mobile Native Sharing**: On mobile devices, could integrate with native sharing APIs (Web Share API) to allow sharing through the device's native share menu (SMS, email, social media, etc.).
+5. **Share Link History**: Track previously generated share links in localStorage, allowing users to easily access and re-share recent configurations.
+6. **Share Link Validation**: Add a "Test Link" feature that validates a share link works correctly before sharing it with others.
+7. **Better Error Recovery**: When encountering partially corrupted share links, attempt to recover and load what's possible rather than showing a complete error (e.g., load config even if injections are corrupted).
+8. **Share Link Expiration**: Add optional expiration dates or time-to-live (TTL) for share links, useful for temporary sharing scenarios.
+9. **Compression Optimization**: Investigate alternative compression algorithms or compression settings that might provide better compression ratios for large configurations while maintaining URL safety.
 
 ## Ergogen Version Override Lifecycle
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -625,3 +625,14 @@ Proposed Fix: I will break down the runGeneration function into several smaller,
 
 1. When filtering out outlines or templates during ZIP/EKB loads, GitHub loads, or URL hash fragment loads, collect the names of any skipped files.
 2. If any files were skipped, display a non-intrusive warning notification or banner (e.g. using `src/organisms/Banners.tsx`) informing the user that some outlines or templates were skipped because the running Ergogen version doesn't support them, recommending that they run the version of the app supporting Ergogen `v4.3.0` or higher to use these libraries.
+
+### [TASK-018] Enhance Share Compatibility Dialog with Badges and Analytics
+
+**Context:** The `ShareVersionCompatibilityDialog` warning dialog displays simple warning text sections for version mismatches. It does not track acceptance or cancellation events, nor does it display prominent visual icons/badges.
+
+**Task:** Enhance the version compatibility check workflow:
+
+1. Add visually prominent warning icons or status badges (e.g., using curated SVG icons matching the theme warning state color) inside each mismatch block in `ShareVersionCompatibilityDialog`.
+2. Add a GitHub icon or pill badge for custom repository references to make links stand out.
+3. Integrate analytics event tracking when compatibility dialog decisions are made, logging `share_compatibility_accept` and `share_compatibility_cancel` events with metadata detailing the current and shared version parameters.
+4. Add corresponding unit tests to verify the events are sent and icons render properly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ergogen-gui",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A web-based GUI for Ergogen, the ergonomic keyboard layout generator.",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ergogen-gui",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "A web-based GUI for Ergogen, the ergonomic keyboard layout generator.",
   "license": "MIT",
   "private": false,

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -122,7 +122,7 @@ describe('App shared version compatibility checks', () => {
       success: true,
       config: {
         config: 'points: {}',
-        guiVersion: '0.9.5', // Newer
+        guiVersion: '0.11.0', // Newer than 0.10.0
         ergogenVersion: 'github:ergogen/ergogen#v4.2.1',
       },
     });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import App from './App';
 import { getConfigFromHash } from './utils/share';
+import guiPkg from '../package.json';
+
+// Parse dynamic package versions for mock matching
+const currentGuiVersion = guiPkg.version;
+const [major, minor, patch] = currentGuiVersion.split('.').map(Number);
+const newerGuiVersion = `${major}.${minor + 1}.${patch}`;
+const olderGuiVersion = `${major}.${minor - 1 >= 0 ? minor - 1 : 0}.${patch}`;
 
 // Mock react-router-dom components and hooks to avoid React Router compatibility issues in Jest
 jest.mock('react-router-dom', () => ({
@@ -105,7 +112,7 @@ describe('App shared version compatibility checks', () => {
       success: true,
       config: {
         config: 'points: {}',
-        guiVersion: '0.8.9', // Matches current (0.8.9)
+        guiVersion: olderGuiVersion, // Matches or older
         ergogenVersion: 'github:ergogen/ergogen#v4.2.1', // Official
       },
     });
@@ -122,7 +129,7 @@ describe('App shared version compatibility checks', () => {
       success: true,
       config: {
         config: 'points: {}',
-        guiVersion: '0.11.0', // Newer than 0.10.0
+        guiVersion: newerGuiVersion, // Newer
         ergogenVersion: 'github:ergogen/ergogen#v4.2.1',
       },
     });
@@ -148,7 +155,7 @@ describe('App shared version compatibility checks', () => {
       success: true,
       config: {
         config: 'points: {}',
-        guiVersion: '0.8.9',
+        guiVersion: currentGuiVersion,
         ergogenVersion: 'github:ceoloide/ergogen#v4.3.0', // Custom
       },
     });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import App from './App';
+import { getConfigFromHash } from './utils/share';
+
+// Mock react-router-dom components and hooks to avoid React Router compatibility issues in Jest
+jest.mock('react-router-dom', () => ({
+  Routes: ({ children }: any) => <div>{children}</div>,
+  Route: ({ element }: any) => element,
+  Navigate: () => <div data-testid="mock-navigate" />,
+  useLocation: () => ({ pathname: '/' }),
+}));
+
+// Mock Ergogen component
+jest.mock('./Ergogen', () => {
+  const MockErgogen = () => <div data-testid="mock-ergogen" />;
+  MockErgogen.displayName = 'MockErgogen';
+  return {
+    __esModule: true,
+    default: MockErgogen,
+  };
+});
+
+// Mock Welcome component
+jest.mock('./pages/Welcome', () => {
+  const MockWelcome = () => <div data-testid="mock-welcome" />;
+  MockWelcome.displayName = 'MockWelcome';
+  return {
+    __esModule: true,
+    default: MockWelcome,
+  };
+});
+
+// Mock Header component
+jest.mock('./atoms/Header', () => {
+  const MockHeader = () => <div data-testid="mock-header" />;
+  MockHeader.displayName = 'MockHeader';
+  return {
+    __esModule: true,
+    default: MockHeader,
+  };
+});
+
+// Mock LoadingBar component
+jest.mock('./atoms/LoadingBar', () => {
+  const MockLoadingBar = () => <div data-testid="mock-loading-bar" />;
+  MockLoadingBar.displayName = 'MockLoadingBar';
+  return {
+    __esModule: true,
+    default: MockLoadingBar,
+  };
+});
+
+// Mock Banners component
+jest.mock('./organisms/Banners', () => {
+  const MockBanners = () => <div data-testid="mock-banners" />;
+  MockBanners.displayName = 'MockBanners';
+  return {
+    __esModule: true,
+    default: MockBanners,
+  };
+});
+
+// Mock SideNavigation component
+jest.mock('./molecules/SideNavigation', () => {
+  const MockSideNavigation = () => <div data-testid="mock-side-navigation" />;
+  MockSideNavigation.displayName = 'MockSideNavigation';
+  return {
+    __esModule: true,
+    default: MockSideNavigation,
+  };
+});
+
+// Mock worker Factory
+jest.mock('./workers/workerFactory', () => ({
+  createErgogenWorker: () => ({
+    postMessage: jest.fn(),
+    terminate: jest.fn(),
+    onmessage: null,
+  }),
+  createJscadWorker: () => ({
+    postMessage: jest.fn(),
+    terminate: jest.fn(),
+    onmessage: null,
+  }),
+}));
+
+// Mock getConfigFromHash
+jest.mock('./utils/share', () => {
+  const originalModule = jest.requireActual('./utils/share');
+  return {
+    ...originalModule,
+    getConfigFromHash: jest.fn(),
+  };
+});
+
+describe('App shared version compatibility checks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('verifies version checking workflow during mount and subsequent hash changes', () => {
+    // 1. Initial mount with compatible configuration
+    (getConfigFromHash as jest.Mock).mockReturnValue({
+      success: true,
+      config: {
+        config: 'points: {}',
+        guiVersion: '0.8.9', // Matches current (0.8.9)
+        ergogenVersion: 'github:ergogen/ergogen#v4.2.1', // Official
+      },
+    });
+
+    render(<App />);
+
+    // Verify dialog is NOT shown initially
+    expect(
+      screen.queryByTestId('share-compatibility-dialog')
+    ).not.toBeInTheDocument();
+
+    // 2. Simulate hash change to a warning configuration (newer GUI version)
+    (getConfigFromHash as jest.Mock).mockReturnValue({
+      success: true,
+      config: {
+        config: 'points: {}',
+        guiVersion: '0.9.5', // Newer
+        ergogenVersion: 'github:ergogen/ergogen#v4.2.1',
+      },
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event('hashchange'));
+    });
+
+    // Verify warning dialog is displayed
+    expect(
+      screen.getByTestId('share-compatibility-dialog')
+    ).toBeInTheDocument();
+    expect(screen.getByText('GUI Version Mismatch')).toBeInTheDocument();
+
+    // 3. Verify Cancel action (dialog disappears)
+    fireEvent.click(screen.getByTestId('share-compatibility-dialog-cancel'));
+    expect(
+      screen.queryByTestId('share-compatibility-dialog')
+    ).not.toBeInTheDocument();
+
+    // 4. Simulate another hash change to a custom Ergogen version
+    (getConfigFromHash as jest.Mock).mockReturnValue({
+      success: true,
+      config: {
+        config: 'points: {}',
+        guiVersion: '0.8.9',
+        ergogenVersion: 'github:ceoloide/ergogen#v4.3.0', // Custom
+      },
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event('hashchange'));
+    });
+
+    // Verify warning dialog is displayed
+    expect(
+      screen.getByTestId('share-compatibility-dialog')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Custom Ergogen Version Used')).toBeInTheDocument();
+
+    // 5. Verify Accept action (dialog disappears)
+    fireEvent.click(screen.getByTestId('share-compatibility-dialog-accept'));
+    expect(
+      screen.queryByTestId('share-compatibility-dialog')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,19 @@ import { useInjectionConflictResolution } from './hooks/useInjectionConflictReso
 import BulkDownloadDialog from './molecules/BulkDownloadDialog';
 import { trackEvent } from './utils/analytics';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
+import guiPkg from '../package.json';
+import ergogenPkg from 'ergogen/package.json';
+import {
+  parseVersion,
+  compareVersions,
+  getSemverFromErgogenVersion,
+  isCustomErgogenVersion,
+  getFullErgogenVersion,
+  getErgogenVersionInfo,
+} from './utils/version';
+import ShareVersionCompatibilityDialog, {
+  VersionCompatibilityReport,
+} from './molecules/ShareVersionCompatibilityDialog';
 
 // Module-level variable to persist hash result across React StrictMode remounts
 // React StrictMode in dev mode intentionally remounts components, which resets refs
@@ -44,6 +57,8 @@ const App = () => {
   const pendingSharedConfigRef = useRef<{
     config: string;
     injections?: string[][];
+    guiVersion?: string;
+    ergogenVersion?: string;
   } | null>(null);
 
   if (hashResult) {
@@ -56,6 +71,8 @@ const App = () => {
         pendingSharedConfigRef.current = {
           config: sharedConfig.config,
           injections: sharedConfig.injections,
+          guiVersion: sharedConfig.guiVersion,
+          ergogenVersion: sharedConfig.ergogenVersion,
         };
       }
 
@@ -86,6 +103,8 @@ const App = () => {
   const [pendingSharedConfig, setPendingSharedConfig] = useState<{
     config: string;
     injections?: string[][];
+    guiVersion?: string;
+    ergogenVersion?: string;
   } | null>(null);
 
   // Set state from ref on mount to ensure it's available for AppContent
@@ -233,7 +252,12 @@ function usePwaInstallPrompt(): (() => void) | undefined {
 const AppContent = ({
   pendingSharedConfig,
 }: {
-  pendingSharedConfig?: { config: string; injections?: string[][] } | null;
+  pendingSharedConfig?: {
+    config: string;
+    injections?: string[][];
+    guiVersion?: string;
+    ergogenVersion?: string;
+  } | null;
 }) => {
   const configContext = useConfigContext();
   // Get configInput from context to ensure we have the latest value
@@ -288,6 +312,113 @@ const AppContent = ({
     setError: (error) => configContext?.setError(error),
   });
 
+  const [sharedConfigToConfirm, setSharedConfigToConfirm] = useState<{
+    config: string;
+    injections?: string[][];
+    report: VersionCompatibilityReport;
+  } | null>(null);
+
+  const checkVersionCompatibility = (
+    sharedGui?: string,
+    sharedErgogen?: string
+  ): VersionCompatibilityReport => {
+    const currentGui = guiPkg.version;
+    const currentErgogen = getFullErgogenVersion(
+      process.env.REACT_APP_ERGOGEN_VERSION
+    );
+
+    let isCompatible = true;
+    let guiWarning: VersionCompatibilityReport['guiWarning'];
+    let ergogenWarning: VersionCompatibilityReport['ergogenWarning'];
+    let customErgogenWarning: VersionCompatibilityReport['customErgogenWarning'];
+
+    // 1. Check GUI version
+    if (sharedGui) {
+      const parsedCurrent = parseVersion(currentGui);
+      const parsedShared = parseVersion(sharedGui);
+      if (
+        parsedCurrent &&
+        parsedShared &&
+        !compareVersions(parsedCurrent, parsedShared)
+      ) {
+        isCompatible = false;
+        guiWarning = { current: currentGui, shared: sharedGui };
+      }
+    }
+
+    // 2. Check Ergogen version
+    if (sharedErgogen) {
+      // Check if it's custom
+      if (isCustomErgogenVersion(sharedErgogen)) {
+        isCompatible = false;
+        const versionInfo = getErgogenVersionInfo(sharedErgogen);
+        customErgogenWarning = {
+          shared: sharedErgogen,
+          url: versionInfo.url,
+          label: versionInfo.label,
+        };
+      }
+
+      // Check if current is older
+      const currentSemver =
+        getSemverFromErgogenVersion(currentErgogen) || ergogenPkg.version;
+      const sharedSemver = getSemverFromErgogenVersion(sharedErgogen);
+      if (currentSemver && sharedSemver) {
+        const parsedCurrent = parseVersion(currentSemver);
+        const parsedShared = parseVersion(sharedSemver);
+        if (
+          parsedCurrent &&
+          parsedShared &&
+          !compareVersions(parsedCurrent, parsedShared)
+        ) {
+          isCompatible = false;
+          ergogenWarning = { current: currentSemver, shared: sharedSemver };
+        }
+      }
+    }
+
+    return {
+      isCompatible,
+      guiWarning,
+      ergogenWarning,
+      customErgogenWarning,
+    };
+  };
+
+  const loadSharedConfig = (config: string, injections?: string[][]) => {
+    if (!configContext) return;
+
+    if (injections !== undefined && injections.length > 0) {
+      processInjectionsWithConflictResolution(injections, config).catch(
+        (error) => {
+          console.error('[App] Error processing injections:', error);
+          configContext.setError(
+            `Failed to process injections: ${error instanceof Error ? error.message : 'Unknown error'}`
+          );
+        }
+      );
+    } else {
+      configContext.loadPreview(config);
+      configContext.generateNow(config, configContext.injectionInput, {
+        pointsonly: false,
+      });
+    }
+  };
+
+  const handleAcceptShare = () => {
+    if (sharedConfigToConfirm) {
+      loadSharedConfig(
+        sharedConfigToConfirm.config,
+        sharedConfigToConfirm.injections
+      );
+      setSharedConfigToConfirm(null);
+    }
+  };
+
+  const handleCancelShare = () => {
+    setSharedConfigToConfirm(null);
+  };
+
   /**
    * Effect to process pending shared config from initial hash fragment load.
    * This processes the config with conflict resolution after React has rendered.
@@ -311,43 +442,25 @@ const AppContent = ({
     // Mark as processed to prevent re-processing on re-renders
     hasProcessedInitialSharedConfig.current = true;
 
-    // Process the pending shared config with conflict resolution
+    // Perform version check!
+    const report = checkVersionCompatibility(
+      pendingSharedConfig.guiVersion,
+      pendingSharedConfig.ergogenVersion
+    );
 
-    if (
-      pendingSharedConfig.injections !== undefined &&
-      pendingSharedConfig.injections.length > 0
-    ) {
-      // If we have injections, we defer setting the config until conflicts are resolved.
-      // The processInjectionsWithConflictResolution function will handle setting the config
-      // once resolution is complete (or if there are no conflicts).
-      processInjectionsWithConflictResolution(
-        pendingSharedConfig.injections,
-        pendingSharedConfig.config
-      ).catch((error) => {
-        console.error(
-          '[App] Error processing injections from initial hash:',
-          error
-        );
-        configContext.setError(
-          `Failed to process injections: ${error instanceof Error ? error.message : 'Unknown error'}`
-        );
+    if (!report.isCompatible) {
+      setSharedConfigToConfirm({
+        config: pendingSharedConfig.config,
+        injections: pendingSharedConfig.injections,
+        report,
       });
     } else {
-      // No injections to process, just set config in preview state and generate
-      configContext.loadPreview(pendingSharedConfig.config);
-      configContext.generateNow(
+      loadSharedConfig(
         pendingSharedConfig.config,
-        configContext.injectionInput,
-        {
-          pointsonly: false,
-        }
+        pendingSharedConfig.injections
       );
     }
-  }, [
-    configContext,
-    pendingSharedConfig,
-    processInjectionsWithConflictResolution,
-  ]); // Re-run when configContext or pendingSharedConfig becomes available
+  }, [configContext, pendingSharedConfig]);
 
   /**
    * Effect to handle hash fragment changes when navigating to shared configurations.
@@ -367,33 +480,21 @@ const AppContent = ({
 
       if (hashResult.success) {
         const sharedConfig = hashResult.config;
-        // Process injections with conflict resolution
-        if (
-          sharedConfig.injections !== undefined &&
-          sharedConfig.injections.length > 0
-        ) {
-          // Defer setting config until resolution is complete
-          processInjectionsWithConflictResolution(
-            sharedConfig.injections,
-            sharedConfig.config
-          ).catch((error) => {
-            console.error('[App] Error processing injections:', error);
-            configContext.setError(
-              `Failed to process injections: ${error instanceof Error ? error.message : 'Unknown error'}`
-            );
+
+        // Perform version check!
+        const report = checkVersionCompatibility(
+          sharedConfig.guiVersion,
+          sharedConfig.ergogenVersion
+        );
+
+        if (!report.isCompatible) {
+          setSharedConfigToConfirm({
+            config: sharedConfig.config,
+            injections: sharedConfig.injections,
+            report,
           });
         } else {
-          // No injections, safe to update config immediately in preview state
-          configContext.loadPreview(sharedConfig.config);
-
-          // No injections to process, just generate
-          configContext.generateNow(
-            sharedConfig.config,
-            configContext.injectionInput,
-            {
-              pointsonly: false,
-            }
-          );
+          loadSharedConfig(sharedConfig.config, sharedConfig.injections);
         }
 
         // Clear the hash fragment after loading
@@ -428,10 +529,18 @@ const AppContent = ({
     return () => {
       window.removeEventListener('hashchange', handleHashChange);
     };
-  }, [configContext, processInjectionsWithConflictResolution]);
+  }, [configContext]);
 
   return (
     <>
+      {sharedConfigToConfirm && (
+        <ShareVersionCompatibilityDialog
+          report={sharedConfigToConfirm.report}
+          onAccept={handleAcceptShare}
+          onCancel={handleCancelShare}
+          data-testid="share-compatibility-dialog"
+        />
+      )}
       {currentConflict && (
         <ConflictResolutionDialog
           injectionName={currentConflict.name}

--- a/src/molecules/ShareVersionCompatibilityDialog.test.tsx
+++ b/src/molecules/ShareVersionCompatibilityDialog.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ShareVersionCompatibilityDialog, {
+  VersionCompatibilityReport,
+} from './ShareVersionCompatibilityDialog';
+
+describe('ShareVersionCompatibilityDialog', () => {
+  const mockOnAccept = jest.fn();
+  const mockOnCancel = jest.fn();
+
+  beforeEach(() => {
+    mockOnAccept.mockClear();
+    mockOnCancel.mockClear();
+  });
+
+  it('renders GUI warning correctly', () => {
+    const report: VersionCompatibilityReport = {
+      isCompatible: false,
+      guiWarning: {
+        current: '0.8.9',
+        shared: '0.9.0',
+      },
+    };
+
+    render(
+      <ShareVersionCompatibilityDialog
+        report={report}
+        onAccept={mockOnAccept}
+        onCancel={mockOnCancel}
+        data-testid="compat-dialog"
+      />
+    );
+
+    expect(
+      screen.getByText('Version Compatibility Warning')
+    ).toBeInTheDocument();
+    expect(screen.getByText('GUI Version Mismatch')).toBeInTheDocument();
+    expect(screen.getByText(/newer version of the GUI/)).toBeInTheDocument();
+    expect(screen.getByText('v0.9.0')).toBeInTheDocument();
+    expect(screen.getByText('v0.8.9')).toBeInTheDocument();
+  });
+
+  it('renders Ergogen warning correctly', () => {
+    const report: VersionCompatibilityReport = {
+      isCompatible: false,
+      ergogenWarning: {
+        current: '4.2.1',
+        shared: '4.3.0',
+      },
+    };
+
+    render(
+      <ShareVersionCompatibilityDialog
+        report={report}
+        onAccept={mockOnAccept}
+        onCancel={mockOnCancel}
+        data-testid="compat-dialog"
+      />
+    );
+
+    expect(screen.getByText('Ergogen Version Mismatch')).toBeInTheDocument();
+    expect(screen.getByText(/newer version of Ergogen/)).toBeInTheDocument();
+    expect(screen.getByText('4.3.0')).toBeInTheDocument();
+    expect(screen.getByText('4.2.1')).toBeInTheDocument();
+  });
+
+  it('renders Custom Ergogen warning with clickable repo link correctly', () => {
+    const report: VersionCompatibilityReport = {
+      isCompatible: false,
+      customErgogenWarning: {
+        shared: 'github:ceoloide/ergogen#v4.3.0',
+        url: 'https://github.com/ceoloide/ergogen/tree/v4.3.0',
+        label: 'ceoloide/ergogen#v4.3.0',
+      },
+    };
+
+    render(
+      <ShareVersionCompatibilityDialog
+        report={report}
+        onAccept={mockOnAccept}
+        onCancel={mockOnCancel}
+        data-testid="compat-dialog"
+      />
+    );
+
+    expect(screen.getByText('Custom Ergogen Version Used')).toBeInTheDocument();
+    expect(screen.getByText(/custom version of Ergogen:/)).toBeInTheDocument();
+    expect(
+      screen.getByText('github:ceoloide/ergogen#v4.3.0')
+    ).toBeInTheDocument();
+
+    const link = screen.getByTestId('compat-dialog-custom-repo-link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      'href',
+      'https://github.com/ceoloide/ergogen/tree/v4.3.0'
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(screen.getByText('ceoloide/ergogen#v4.3.0')).toBeInTheDocument();
+  });
+
+  it('calls onAccept when Accept and Load button is clicked', () => {
+    const report: VersionCompatibilityReport = {
+      isCompatible: false,
+      guiWarning: {
+        current: '0.8.9',
+        shared: '0.9.0',
+      },
+    };
+
+    render(
+      <ShareVersionCompatibilityDialog
+        report={report}
+        onAccept={mockOnAccept}
+        onCancel={mockOnCancel}
+        data-testid="compat-dialog"
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('compat-dialog-accept'));
+    expect(mockOnAccept).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when Cancel button is clicked', () => {
+    const report: VersionCompatibilityReport = {
+      isCompatible: false,
+      guiWarning: {
+        current: '0.8.9',
+        shared: '0.9.0',
+      },
+    };
+
+    render(
+      <ShareVersionCompatibilityDialog
+        report={report}
+        onAccept={mockOnAccept}
+        onCancel={mockOnCancel}
+        data-testid="compat-dialog"
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('compat-dialog-cancel'));
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('has accessible labels for interactive buttons', () => {
+    const report: VersionCompatibilityReport = {
+      isCompatible: false,
+      guiWarning: {
+        current: '0.8.9',
+        shared: '0.9.0',
+      },
+    };
+
+    render(
+      <ShareVersionCompatibilityDialog
+        report={report}
+        onAccept={mockOnAccept}
+        onCancel={mockOnCancel}
+        data-testid="compat-dialog"
+      />
+    );
+
+    expect(
+      screen.getByLabelText('Accept and load configuration')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Cancel configuration loading')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/molecules/ShareVersionCompatibilityDialog.tsx
+++ b/src/molecules/ShareVersionCompatibilityDialog.tsx
@@ -1,0 +1,222 @@
+import React from 'react';
+import styled from 'styled-components';
+import { theme } from '../theme/theme';
+import Button from '../atoms/Button';
+
+export interface VersionCompatibilityReport {
+  isCompatible: boolean;
+  guiWarning?: {
+    current: string;
+    shared: string;
+  };
+  ergogenWarning?: {
+    current: string;
+    shared: string;
+  };
+  customErgogenWarning?: {
+    shared: string;
+    url: string;
+    label: string;
+  };
+}
+
+type ShareVersionCompatibilityDialogProps = {
+  report: VersionCompatibilityReport;
+  onAccept: () => void;
+  onCancel: () => void;
+  'data-testid'?: string;
+};
+
+const ShareVersionCompatibilityDialog: React.FC<
+  ShareVersionCompatibilityDialogProps
+> = ({ report, onAccept, onCancel, 'data-testid': dataTestId }) => {
+  return (
+    <Overlay data-testid={dataTestId}>
+      <DialogBox data-testid={dataTestId && `${dataTestId}-box`}>
+        <Title>Version Compatibility Warning</Title>
+        <Subtitle>
+          The shared link was created under a different environment. You may
+          experience compatibility issues.
+        </Subtitle>
+
+        <WarningContainer>
+          {report.guiWarning && (
+            <WarningBox data-testid={dataTestId && `${dataTestId}-gui-warning`}>
+              <WarningLabel>GUI Version Mismatch</WarningLabel>
+              <WarningDescription>
+                The shared link was created with a newer version of the GUI (
+                <strong>v{report.guiWarning.shared}</strong>) than your current
+                version (<strong>v{report.guiWarning.current}</strong>). Some
+                interface options or features may not function as expected.
+              </WarningDescription>
+            </WarningBox>
+          )}
+
+          {report.ergogenWarning && (
+            <WarningBox
+              data-testid={dataTestId && `${dataTestId}-ergogen-warning`}
+            >
+              <WarningLabel>Ergogen Version Mismatch</WarningLabel>
+              <WarningDescription>
+                The shared link was created with a newer version of Ergogen (
+                <strong>{report.ergogenWarning.shared}</strong>) than your
+                current version (
+                <strong>{report.ergogenWarning.current}</strong>). Some features
+                or syntax might not be supported.
+              </WarningDescription>
+            </WarningBox>
+          )}
+
+          {report.customErgogenWarning && (
+            <WarningBox
+              data-testid={dataTestId && `${dataTestId}-custom-ergogen-warning`}
+            >
+              <WarningLabel>Custom Ergogen Version Used</WarningLabel>
+              <WarningDescription>
+                The shared link was created using a custom version of Ergogen:{' '}
+                <strong>{report.customErgogenWarning.shared}</strong>.
+                <br />
+                You can investigate the repository used here:
+                <br />
+                <RepoLink
+                  href={report.customErgogenWarning.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-testid={dataTestId && `${dataTestId}-custom-repo-link`}
+                >
+                  {report.customErgogenWarning.label}
+                </RepoLink>
+              </WarningDescription>
+            </WarningBox>
+          )}
+        </WarningContainer>
+
+        <ButtonGroup>
+          <CancelButton
+            onClick={onCancel}
+            size="medium"
+            data-testid={dataTestId && `${dataTestId}-cancel`}
+            aria-label="Cancel configuration loading"
+          >
+            Cancel
+          </CancelButton>
+          <AcceptButton
+            onClick={onAccept}
+            size="medium"
+            data-testid={dataTestId && `${dataTestId}-accept`}
+            aria-label="Accept and load configuration"
+          >
+            Accept and Load
+          </AcceptButton>
+        </ButtonGroup>
+      </DialogBox>
+    </Overlay>
+  );
+};
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+`;
+
+const DialogBox = styled.div`
+  background-color: ${theme.colors.backgroundLight};
+  border: 1px solid ${theme.colors.border};
+  border-radius: 8px;
+  padding: 2rem;
+  max-width: 550px;
+  width: 90%;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+`;
+
+const Title = styled.h2`
+  margin: 0 0 0.5rem 0;
+  font-size: ${theme.fontSizes.h3};
+  color: ${theme.colors.error};
+`;
+
+const Subtitle = styled.p`
+  margin: 0 0 1.5rem 0;
+  font-size: ${theme.fontSizes.base};
+  color: ${theme.colors.textDarker};
+  line-height: 1.4;
+`;
+
+const WarningContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 2rem;
+`;
+
+const WarningBox = styled.div`
+  background-color: ${theme.colors.backgroundLighter};
+  border-left: 4px solid ${theme.colors.warningDark};
+  padding: 1rem;
+  border-radius: 4px;
+`;
+
+const WarningLabel = styled.div`
+  font-size: ${theme.fontSizes.base};
+  font-weight: ${theme.fontWeights.bold};
+  color: ${theme.colors.warningDark};
+  margin-bottom: 0.25rem;
+`;
+
+const WarningDescription = styled.div`
+  font-size: ${theme.fontSizes.bodySmall};
+  color: ${theme.colors.textDark};
+  line-height: 1.5;
+
+  strong {
+    color: ${theme.colors.text};
+  }
+`;
+
+const RepoLink = styled.a`
+  display: inline-block;
+  margin-top: 0.5rem;
+  color: ${theme.colors.accent};
+  text-decoration: underline;
+  word-break: break-all;
+
+  &:hover {
+    color: ${theme.colors.accentSecondary};
+  }
+`;
+
+const ButtonGroup = styled.div`
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+`;
+
+const AcceptButton = styled(Button)`
+  background-color: ${theme.colors.accent};
+  color: ${theme.colors.white};
+
+  &:hover {
+    background-color: ${theme.colors.accentDark};
+  }
+`;
+
+const CancelButton = styled(Button)`
+  background-color: ${theme.colors.backgroundLighter};
+  color: ${theme.colors.textDark};
+
+  &:hover {
+    background-color: ${theme.colors.buttonHover};
+  }
+`;
+
+export default ShareVersionCompatibilityDialog;

--- a/src/utils/featureFlags.test.ts
+++ b/src/utils/featureFlags.test.ts
@@ -5,11 +5,8 @@ jest.mock('ergogen/package.json', () => ({
   },
 }));
 
-import {
-  isFeatureEnabled,
-  parseVersion,
-  compareVersions,
-} from './featureFlags';
+import { isFeatureEnabled } from './featureFlags';
+import { parseVersion, compareVersions } from './version';
 
 describe('featureFlags utilities', () => {
   describe('parseVersion', () => {

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -1,4 +1,8 @@
-import { getErgogenVersionInfo } from './version';
+import {
+  getErgogenVersionInfo,
+  parseVersion,
+  compareVersions,
+} from './version';
 import ergogenPkg from 'ergogen/package.json';
 
 type FeatureName = 'templates' | 'outlines';
@@ -7,31 +11,6 @@ type FeatureName = 'templates' | 'outlines';
 const FEATURE_VERSION_REQUIREMENTS: Record<FeatureName, string> = {
   templates: '4.3.0',
   outlines: '4.3.0',
-};
-
-/**
- * Parses a version string into [major, minor, patch] numbers.
- * Returns null if the version string is not standard.
- */
-export const parseVersion = (v: string): [number, number, number] | null => {
-  const clean = v.replace(/^v/, '');
-  const match = clean.match(/^(\d+)\.(\d+)\.(\d+)/);
-  if (!match) return null;
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
-};
-
-/**
- * Compares two parsed versions. Returns true if v1 >= v2.
- */
-export const compareVersions = (
-  v1: [number, number, number],
-  v2: [number, number, number]
-): boolean => {
-  for (let i = 0; i < 3; i++) {
-    if (v1[i] > v2[i]) return true;
-    if (v1[i] < v2[i]) return false;
-  }
-  return true; // Equal
 };
 
 /**

--- a/src/utils/share.test.ts
+++ b/src/utils/share.test.ts
@@ -96,6 +96,39 @@ describe('share utilities', () => {
         expect(decoded.message).toBeTruthy();
       }
     });
+
+    it('decodes config with custom version values', () => {
+      const customGui = '1.2.3';
+      const customErgogen = 'github:myfork/ergogen#v4.5.6';
+      const encoded = encodeConfig(
+        testConfig,
+        undefined,
+        customGui,
+        customErgogen
+      );
+      const decoded = decodeConfig(encoded);
+      expect(decoded.success).toBe(true);
+      if (decoded.success) {
+        expect(decoded.config.guiVersion).toBe(customGui);
+        expect(decoded.config.ergogenVersion).toBe(customErgogen);
+      }
+    });
+
+    it('uses fallback values for guiVersion and ergogenVersion when they are missing in payload', () => {
+      // Create a payload that has config but lacks guiVersion and ergogenVersion
+      const legacyPayload = JSON.stringify({
+        config: testConfig,
+      });
+      const encoded = compressToEncodedURIComponent(legacyPayload);
+      const decoded = decodeConfig(encoded);
+      expect(decoded.success).toBe(true);
+      if (decoded.success) {
+        expect(decoded.config.guiVersion).toBe('0.9.0');
+        expect(decoded.config.ergogenVersion).toBe(
+          'github:ergogen/ergogen#v4.2.1'
+        );
+      }
+    });
   });
 
   describe('createShareableUri', () => {

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -2,6 +2,8 @@ import {
   compressToEncodedURIComponent,
   decompressFromEncodedURIComponent,
 } from 'lz-string';
+import guiPkg from '../../package.json';
+import { getFullErgogenVersion } from './version';
 
 /**
  * Structure for sharing keyboard configuration.
@@ -10,6 +12,8 @@ import {
 export interface ShareableConfig {
   config: string;
   injections?: string[][];
+  guiVersion?: string;
+  ergogenVersion?: string;
 }
 
 /**
@@ -18,16 +22,24 @@ export interface ShareableConfig {
  *
  * @param config - The YAML/JSON configuration string
  * @param injections - Optional array of injections (footprints, templates, etc.)
+ * @param guiVersion - Optional override for GUI version (defaults to package.json version)
+ * @param ergogenVersion - Optional override for Ergogen version (defaults to resolved env version)
  * @returns Encoded and compressed string suitable for URI fragment
  */
 export const encodeConfig = (
   config: string,
-  injections?: string[][]
+  injections?: string[][],
+  guiVersion?: string,
+  ergogenVersion?: string
 ): string => {
   const shareableConfig: ShareableConfig = {
     config,
     // Include all injections if present
     ...(injections && injections.length > 0 ? { injections } : {}),
+    guiVersion: guiVersion || guiPkg.version,
+    ergogenVersion:
+      ergogenVersion ||
+      getFullErgogenVersion(process.env.REACT_APP_ERGOGEN_VERSION),
   };
 
   const jsonString = JSON.stringify(shareableConfig);
@@ -117,6 +129,20 @@ export const decodeConfig = (encodedString: string): DecodeResult => {
     }
 
     const shareableConfig = parsed as ShareableConfig;
+
+    // Apply fallbacks if version information is missing or invalid
+    if (
+      !shareableConfig.guiVersion ||
+      typeof shareableConfig.guiVersion !== 'string'
+    ) {
+      shareableConfig.guiVersion = '0.9.0';
+    }
+    if (
+      !shareableConfig.ergogenVersion ||
+      typeof shareableConfig.ergogenVersion !== 'string'
+    ) {
+      shareableConfig.ergogenVersion = 'github:ergogen/ergogen#v4.2.1';
+    }
 
     // Validate injections if present
     if (

--- a/src/utils/version.test.ts
+++ b/src/utils/version.test.ts
@@ -1,4 +1,11 @@
-import { getErgogenVersionInfo, getFullErgogenVersion } from './version';
+import {
+  getErgogenVersionInfo,
+  getFullErgogenVersion,
+  parseVersion,
+  compareVersions,
+  getSemverFromErgogenVersion,
+  isCustomErgogenVersion,
+} from './version';
 import ergogenPkg from 'ergogen/package.json';
 
 describe('getErgogenVersionInfo', () => {
@@ -160,5 +167,46 @@ describe('getFullErgogenVersion', () => {
     expect(getFullErgogenVersion(`github:ceoloide/ergogen#${fullHash}`)).toBe(
       `github:ceoloide/ergogen#${fullHash}`
     );
+  });
+});
+
+describe('parseVersion and compareVersions', () => {
+  it('correctly parses semver strings', () => {
+    expect(parseVersion('1.2.3')).toEqual([1, 2, 3]);
+    expect(parseVersion('v0.8.9')).toEqual([0, 8, 9]);
+    expect(parseVersion('10.20.30-beta')).toEqual([10, 20, 30]);
+    expect(parseVersion('invalid')).toBeNull();
+  });
+
+  it('compares parsed versions correctly', () => {
+    expect(compareVersions([4, 3, 0], [4, 2, 1])).toBe(true);
+    expect(compareVersions([4, 3, 0], [4, 3, 0])).toBe(true);
+    expect(compareVersions([5, 0, 0], [4, 3, 0])).toBe(true);
+    expect(compareVersions([4, 2, 1], [4, 3, 0])).toBe(false);
+    expect(compareVersions([3, 9, 9], [4, 0, 0])).toBe(false);
+  });
+});
+
+describe('getSemverFromErgogenVersion', () => {
+  it('extracts semver from various formats', () => {
+    expect(getSemverFromErgogenVersion('github:ergogen/ergogen#v4.2.1')).toBe(
+      '4.2.1'
+    );
+    expect(getSemverFromErgogenVersion('github:ceoloide/ergogen#v4.3.0')).toBe(
+      '4.3.0'
+    );
+    expect(getSemverFromErgogenVersion('ergogen@4.2.0')).toBe('4.2.0');
+    expect(
+      getSemverFromErgogenVersion('github:ceoloide/ergogen#develop')
+    ).toBeNull();
+  });
+});
+
+describe('isCustomErgogenVersion', () => {
+  it('identifies custom forks', () => {
+    expect(isCustomErgogenVersion('github:ceoloide/ergogen#v4.3.0')).toBe(true);
+    expect(isCustomErgogenVersion('github:ergogen/ergogen#v4.2.1')).toBe(false);
+    expect(isCustomErgogenVersion('ergogen@4.2.0')).toBe(false);
+    expect(isCustomErgogenVersion('4.2.0')).toBe(false);
   });
 });

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -160,3 +160,53 @@ export const getFullErgogenVersion = (version?: string): string => {
 
   return `github:${repo}#${branch}`;
 };
+
+/**
+ * Parses a version string into [major, minor, patch] numbers.
+ * Returns null if the version string is not standard.
+ */
+export const parseVersion = (v: string): [number, number, number] | null => {
+  const clean = v.replace(/^v/, '');
+  const match = clean.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+};
+
+/**
+ * Compares two parsed versions. Returns true if v1 >= v2.
+ */
+export const compareVersions = (
+  v1: [number, number, number],
+  v2: [number, number, number]
+): boolean => {
+  for (let i = 0; i < 3; i++) {
+    if (v1[i] > v2[i]) return true;
+    if (v1[i] < v2[i]) return false;
+  }
+  return true; // Equal
+};
+
+/**
+ * Extracts a semver string (X.Y.Z) from an Ergogen version string.
+ * Returns null if no semver pattern is found.
+ */
+export const getSemverFromErgogenVersion = (
+  versionStr: string
+): string | null => {
+  const match = versionStr.match(/(?:^|#|@|v)(\d+\.\d+\.\d+)/);
+  return match ? match[1] : null;
+};
+
+/**
+ * Checks if an Ergogen version string represents a custom/forked version.
+ */
+export const isCustomErgogenVersion = (versionStr: string): boolean => {
+  const clean = versionStr.startsWith('github:')
+    ? versionStr.slice(7)
+    : versionStr;
+  const [repo] = clean.split('#');
+  if (!versionStr.startsWith('github:') && !versionStr.includes('/')) {
+    return false;
+  }
+  return repo !== 'ergogen/ergogen';
+};


### PR DESCRIPTION
## Description
This pull request implements environment and version compatibility checks for shareable configuration links in the Ergogen GUI. 

Now, when users share their configuration, the GUI automatically embeds metadata containing the creator's GUI version (from `package.json`) and full Ergogen version (including branch and repository info). On the receiving end, the website compares its current environment versions against the shared link's metadata and displays a warning dialog modal if any mismatches or custom setups are detected, letting the user Accept or Cancel loading.

To ensure backward compatibility, legacy links lacking this metadata fallback to assuming GUI version `0.9.0` and official Ergogen version `4.2.1` (`github:ergogen/ergogen#v4.2.1`).

## What changed
- **Version Metadata Encoding**: Embeds `guiVersion` and `ergogenVersion` in the LZ-compressed shared hash fragment payload.
- **Fallback Support**: Assigns default version parameters to older configuration links lacking version metadata.
- **Version Checking Helpers**: Added utilities in `version.ts` to parse, compare, and verify standard and custom Ergogen version formats.
- **Warning Modal Dialog**: Added `ShareVersionCompatibilityDialog.tsx` showing GUI/Ergogen version mismatch details or custom Ergogen fork warnings (with clickable GitHub repository refs).
- **Control Interception**: Integrates warnings on mount and `hashchange` in `App.tsx` preventing automatic loading until explicitly approved.
- **Testing**: Added unit tests for the modal and share utils, plus unified sequential integration tests in `App.test.tsx`.

## Verification Results
- **Unit Tests**: All unit tests pass successfully (`yarn test:unit`).
- **Build**: Successfully built without errors (`yarn build`).
- **Formatters & Linters**: Formatted and linted cleanly (`yarn precommit`).