### PR TITLE
Update `keyboard_keys` event payload and fix PWA update reload

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -452,6 +452,7 @@ This parses and extracts:
 
 - Outline, PCB, and Case counts
 - Boolean flags like `is_reversible` and `is_mirrored`
+- `keyboard_keys` representing the estimated physical switch count (doubled if reversible and asymmetric, otherwise matching `matrix_keys`)
 - Alpha-sorted granular matrix zone details (zone names, counts, column names, row names, etc.)
 - A deterministic 12-character SHA-256 geometric `config_id` hash of the keyboard layout.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ergogen-gui",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A web-based GUI for Ergogen, the ergonomic keyboard layout generator.",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ergogen-gui",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A web-based GUI for Ergogen, the ergonomic keyboard layout generator.",
   "license": "MIT",
   "private": false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -134,7 +134,7 @@ const App = () => {
  * update chip without needing a deployed SW update (e.g. `/?force_update`).
  * Clicking the chip will simply reload the page.
  */
-function useServiceWorkerUpdate(): (() => void) | undefined {
+export function useServiceWorkerUpdate(): (() => void) | undefined {
   const [waitingRegistration, setWaitingRegistration] =
     useState<ServiceWorkerRegistration | null>(null);
 
@@ -163,14 +163,24 @@ function useServiceWorkerUpdate(): (() => void) | undefined {
   if (!waitingRegistration) return undefined;
 
   return () => {
+    if ('serviceWorker' in navigator) {
+      let refreshing = false;
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if (!refreshing) {
+          refreshing = true;
+          window.location.reload();
+        }
+      });
+    }
+
     // Signal the waiting service worker to skip the waiting phase and activate.
-    waitingRegistration.waiting?.postMessage({ type: 'SKIP_WAITING' });
-    // Once the new SW activates it will control the page; reload to use fresh assets.
-    waitingRegistration.waiting?.addEventListener('statechange', (event) => {
-      if ((event.target as ServiceWorker).state === 'activated') {
-        window.location.reload();
-      }
-    });
+    const worker = waitingRegistration.waiting;
+    if (worker) {
+      worker.postMessage({ type: 'SKIP_WAITING' });
+    } else {
+      // Fallback: reload immediately if there is no waiting worker
+      window.location.reload();
+    }
   };
 }
 

--- a/src/hooks/useServiceWorkerUpdate.test.ts
+++ b/src/hooks/useServiceWorkerUpdate.test.ts
@@ -1,0 +1,178 @@
+import { renderHook, act } from '@testing-library/react';
+import { useServiceWorkerUpdate } from '../App';
+import * as serviceWorkerRegistration from '../serviceWorkerRegistration';
+
+jest.mock('../serviceWorkerRegistration', () => ({
+  register: jest.fn(),
+}));
+
+jest.mock('../Ergogen', () => {
+  const MockErgogen = () => null;
+  MockErgogen.displayName = 'MockErgogen';
+  return {
+    __esModule: true,
+    default: MockErgogen,
+  };
+});
+
+jest.mock('../pages/Welcome', () => {
+  const MockWelcome = () => null;
+  MockWelcome.displayName = 'MockWelcome';
+  return {
+    __esModule: true,
+    default: MockWelcome,
+  };
+});
+
+describe('useServiceWorkerUpdate hook', () => {
+  let mockReload: jest.Mock;
+  let originalNavigator: any;
+  let mockAddEventListener: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock window.location
+    mockReload = jest.fn();
+    Object.defineProperty(window, 'location', {
+      value: {
+        reload: mockReload,
+        search: '',
+      },
+      writable: true,
+    });
+
+    // Mock navigator.serviceWorker
+    mockAddEventListener = jest.fn();
+    originalNavigator = global.navigator;
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        ...originalNavigator,
+        serviceWorker: {
+          addEventListener: mockAddEventListener,
+        },
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(global, 'navigator', {
+      value: originalNavigator,
+      writable: true,
+    });
+  });
+
+  it('should register the service worker on mount', () => {
+    renderHook(() => useServiceWorkerUpdate());
+    expect(serviceWorkerRegistration.register).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return undefined when there is no waiting registration', () => {
+    const { result } = renderHook(() => useServiceWorkerUpdate());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should return a reload callback when ?force_update is present', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        reload: mockReload,
+        search: '?force_update',
+      },
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useServiceWorkerUpdate());
+    expect(result.current).toBeInstanceOf(Function);
+
+    act(() => {
+      result.current?.();
+    });
+
+    expect(mockReload).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle update when click is triggered with a waiting registration', () => {
+    const mockPostMessage = jest.fn();
+    const mockWaitingWorker = {
+      postMessage: mockPostMessage,
+    };
+    const mockRegistration = {
+      waiting: mockWaitingWorker,
+    } as unknown as ServiceWorkerRegistration;
+
+    let onUpdateCallback: any = null;
+    (serviceWorkerRegistration.register as jest.Mock).mockImplementation(
+      (config) => {
+        onUpdateCallback = config.onUpdate;
+      }
+    );
+
+    const { result } = renderHook(() => useServiceWorkerUpdate());
+
+    // Trigger onUpdate callback to simulate waiting service worker
+    act(() => {
+      onUpdateCallback?.(mockRegistration);
+    });
+
+    expect(result.current).toBeInstanceOf(Function);
+
+    // Call the update handler
+    act(() => {
+      result.current?.();
+    });
+
+    // Verify controllerchange listener was added
+    expect(mockAddEventListener).toHaveBeenCalledWith(
+      'controllerchange',
+      expect.any(Function)
+    );
+
+    // Verify message sent to waiting service worker
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+
+    // Retrieve the registered callback and invoke it to test reload trigger
+    const registeredCallback = mockAddEventListener.mock.calls[0][1];
+    expect(mockReload).not.toHaveBeenCalled();
+
+    act(() => {
+      registeredCallback();
+    });
+
+    expect(mockReload).toHaveBeenCalledTimes(1);
+
+    // Test refreshing guard by calling it again; should not trigger reload again
+    act(() => {
+      registeredCallback();
+    });
+    expect(mockReload).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fallback to reload if there is no waiting worker when updated', () => {
+    const mockRegistration = {
+      waiting: null,
+    } as unknown as ServiceWorkerRegistration;
+
+    let onUpdateCallback: any = null;
+    (serviceWorkerRegistration.register as jest.Mock).mockImplementation(
+      (config) => {
+        onUpdateCallback = config.onUpdate;
+      }
+    );
+
+    const { result } = renderHook(() => useServiceWorkerUpdate());
+
+    act(() => {
+      onUpdateCallback?.(mockRegistration);
+    });
+
+    expect(result.current).toBeInstanceOf(Function);
+
+    act(() => {
+      result.current?.();
+    });
+
+    // Should reload immediately as fallback
+    expect(mockReload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/configAnalyzer.test.ts
+++ b/src/utils/configAnalyzer.test.ts
@@ -272,4 +272,100 @@ pt_a:
     // Output string should have two identical coordinates, but the order of sorting should be deterministic.
     expect(payload.config_id).toBeDefined();
   });
+
+  describe('keyboard_keys metric calculation', () => {
+    const pointsYaml = `
+matrix_pinky_bottom:
+  x: 10
+  y: 20
+  r: 0
+  meta:
+    zone:
+      name: matrix
+`;
+
+    it('should equal matrix_keys when is_mirrored = true and is_reversible = true', () => {
+      const canonical = `
+points:
+  zones:
+    matrix:
+      columns:
+        pinky:
+      rows:
+        bottom:
+  mirror: true
+pcbs:
+  main:
+    reversible: true
+`;
+      const payload = analyzeConfiguration(canonical, pointsYaml, 0);
+      expect(payload.is_mirrored).toBe(true);
+      expect(payload.is_reversible).toBe(true);
+      expect(payload.matrix_keys).toBe(2);
+      expect(payload.keyboard_keys).toBe(2);
+    });
+
+    it('should be doubled when is_mirrored = false and is_reversible = true', () => {
+      const canonical = `
+points:
+  zones:
+    matrix:
+      columns:
+        pinky:
+      rows:
+        bottom:
+  mirror: false
+pcbs:
+  main:
+    reversible: true
+`;
+      const payload = analyzeConfiguration(canonical, pointsYaml, 0);
+      expect(payload.is_mirrored).toBe(false);
+      expect(payload.is_reversible).toBe(true);
+      expect(payload.matrix_keys).toBe(1);
+      expect(payload.keyboard_keys).toBe(2);
+    });
+
+    it('should equal matrix_keys when is_mirrored = false and is_reversible = false', () => {
+      const canonical = `
+points:
+  zones:
+    matrix:
+      columns:
+        pinky:
+      rows:
+        bottom:
+  mirror: false
+pcbs:
+  main:
+    reversible: false
+`;
+      const payload = analyzeConfiguration(canonical, pointsYaml, 0);
+      expect(payload.is_mirrored).toBe(false);
+      expect(payload.is_reversible).toBe(false);
+      expect(payload.matrix_keys).toBe(1);
+      expect(payload.keyboard_keys).toBe(1);
+    });
+
+    it('should equal matrix_keys when is_mirrored = true and is_reversible = false', () => {
+      const canonical = `
+points:
+  zones:
+    matrix:
+      columns:
+        pinky:
+      rows:
+        bottom:
+  mirror: true
+pcbs:
+  main:
+    reversible: false
+`;
+      const payload = analyzeConfiguration(canonical, pointsYaml, 0);
+      expect(payload.is_mirrored).toBe(true);
+      expect(payload.is_reversible).toBe(false);
+      expect(payload.matrix_keys).toBe(2);
+      expect(payload.keyboard_keys).toBe(2);
+    });
+  });
 });

--- a/src/utils/configAnalyzer.ts
+++ b/src/utils/configAnalyzer.ts
@@ -20,6 +20,7 @@ export interface KeyboardAnalyticsPayload {
   matrix_col_names: string;
   matrix_row_names: string;
   matrix_keys: number;
+  keyboard_keys: number;
   config_id: string;
   [key: string]: string | number | boolean | undefined;
 }
@@ -345,6 +346,9 @@ export function analyzeConfiguration(
   const fullHash = sha256(hashInput);
   const config_id = fullHash.substring(0, 12);
 
+  const keyboard_keys =
+    !is_mirrored && is_reversible ? matrix_keys * 2 : matrix_keys;
+
   return {
     total_generation_time_ms: totalGenerationTimeMs,
     count_outlines,
@@ -365,6 +369,7 @@ export function analyzeConfiguration(
     matrix_col_names,
     matrix_row_names,
     matrix_keys,
+    keyboard_keys,
     config_id,
   };
 }


### PR DESCRIPTION
# GA4 Analytics Update & PWA Reload Fix

This pull request implements two distinct features and fixes:
1. **Analytics Enhancement (`keyboard_keys`)**: Enhances our GA4 tracking payload with an estimated physical switch count.
2. **PWA Update Activation Fix**: Resolves a race condition where clicking the "Update Available" chip in the Header would fail to trigger a page refresh.

It also bumps the GUI version to `0.11.2` and adds comprehensive unit test coverage for both changes.

---

## 1. GA4 Analytics Update (`keyboard_keys` Parameter)
We want to track the total number of physical keys the finished keyboard is expected to have. 
- The physical switch count matches `matrix_keys` for unibody boards or asymmetrical splits (where `is_mirrored` is true or both `is_mirrored`/`is_reversible` are false).
- For splits using reversible PCBs in tandem (where `is_mirrored` is false and `is_reversible` is true), the active layout represents only one half, so the actual finished keyboard has double the matrix keys of that half.

### Changes:
- **`src/utils/configAnalyzer.ts`**:
  - Added `keyboard_keys` to the `KeyboardAnalyticsPayload` interface definition.
  - Calculated `keyboard_keys` in `analyzeConfiguration()`: `const keyboard_keys = !is_mirrored && is_reversible ? matrix_keys * 2 : matrix_keys;`
- **`src/utils/configAnalyzer.test.ts`**:
  - Implemented 4 unit tests covering all permutations of `is_mirrored` and `is_reversible` properties to verify correct scaling factor.
- **`DEVELOPMENT.md`**:
  - Documented the new `keyboard_keys` tracking metric under *Keyboard Generation Tracking*.

---

## 2. PWA Update Click Action Fix
Previously, when the service worker detected a new version deployment, it displayed the "Update Available" chip, but clicking it took no action.

### Root Cause:
The application registered a `'statechange'` event listener on the transient `waitingRegistration.waiting` reference *after* posting the `SKIP_WAITING` message. Since the service worker starts transition immediately upon receiving the message, the listener was registered too late or on a reference that had already changed/become null, causing the reload event to never fire.

### Fix:
- Modified the `useServiceWorkerUpdate` hook in [App.tsx](file:///Users/mmassarelli/Documents/GitHub/ergogen-gui/src/App.tsx):
  - Listens to the standard `controllerchange` event on `navigator.serviceWorker` to trigger `window.location.reload()`.
  - Registers this listener *before* calling `postMessage({ type: 'SKIP_WAITING' })`.
  - Added a `refreshing` guard boolean to prevent double-reloading.
  - Implemented a fallback reload if `waitingRegistration.waiting` is unavailable when triggered.
- **`src/hooks/useServiceWorkerUpdate.test.ts`**:
  - Created a comprehensive test suite mock-testing hook mount, `?force_update` parameter handling, event listener setup, skip-waiting dispatch, controllerchange reload, and reload guard execution.

---

## Verification
- Ran full validation using `yarn precommit`.
- All checks passed successfully (linter, prettier format, knip unused dependencies check).
- Verified that all 301 unit tests in the suite pass successfully.
