### PR TITLE
Add safety fallback reload and active update feedback

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -429,7 +429,7 @@ CRA's Workbox plugin detects `src/service-worker.ts` and automatically uses `Inj
 3. `serviceWorkerRegistration.ts` fires its `onUpdate` callback with the waiting `ServiceWorkerRegistration`.
 4. `App.tsx`'s `useServiceWorkerUpdate` hook stores the registration and returns an `onUpdate` handler.
 5. `Header.tsx` renders `UpdateChip` (a pulsing green pill) when `onUpdate` is defined.
-6. User clicks the chip → `SKIP_WAITING` is posted to the new SW → SW activates → page reloads with fresh assets.
+6. User clicks the chip → `SKIP_WAITING` is posted to the new SW → SW activates → page reloads with fresh assets (with a 1-second safety fallback reload if the event doesn't fire).
 
 ### Google Analytics & Privacy Controls
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ergogen-gui",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "A web-based GUI for Ergogen, the ergonomic keyboard layout generator.",
   "license": "MIT",
   "private": false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -163,11 +163,16 @@ export function useServiceWorkerUpdate(): (() => void) | undefined {
   if (!waitingRegistration) return undefined;
 
   return () => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
     if ('serviceWorker' in navigator) {
       let refreshing = false;
       navigator.serviceWorker.addEventListener('controllerchange', () => {
         if (!refreshing) {
           refreshing = true;
+          if (timeoutId) {
+            clearTimeout(timeoutId);
+          }
           window.location.reload();
         }
       });
@@ -177,6 +182,10 @@ export function useServiceWorkerUpdate(): (() => void) | undefined {
     const worker = waitingRegistration.waiting;
     if (worker) {
       worker.postMessage({ type: 'SKIP_WAITING' });
+      // Safety fallback: if controllerchange doesn't trigger a reload within 1 second, reload anyway.
+      timeoutId = setTimeout(() => {
+        window.location.reload();
+      }, 1000);
     } else {
       // Fallback: reload immediately if there is no waiting worker
       window.location.reload();

--- a/src/atoms/UpdateChip.test.tsx
+++ b/src/atoms/UpdateChip.test.tsx
@@ -48,4 +48,19 @@ describe('UpdateChip', () => {
     // Assert
     expect(screen.getByTestId('update-chip')).toBeInTheDocument();
   });
+
+  it('changes text to "Updating version..." and disables the button when clicked', () => {
+    // Arrange
+    const onUpdate = jest.fn();
+    render(<UpdateChip onClick={onUpdate} />);
+    const chip = screen.getByRole('button', { name: /update available/i });
+
+    // Act
+    fireEvent.click(chip);
+
+    // Assert
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Updating version...')).toBeInTheDocument();
+    expect(chip).toBeDisabled();
+  });
 });

--- a/src/atoms/UpdateChip.tsx
+++ b/src/atoms/UpdateChip.tsx
@@ -1,4 +1,5 @@
-import styled, { keyframes } from 'styled-components';
+import { useState } from 'react';
+import styled, { keyframes, css } from 'styled-components';
 import { theme } from '../theme/theme';
 
 type Props = {
@@ -14,7 +15,12 @@ const ripple = keyframes`
   100% { box-shadow: 0 0 0 0   ${theme.colors.accent}00; }
 `;
 
-const Chip = styled.button`
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+`;
+
+const Chip = styled.button<{ $isUpdating?: boolean }>`
   display: flex;
   align-items: center;
   gap: 6px;
@@ -28,17 +34,29 @@ const Chip = styled.button`
   font-weight: ${theme.fontWeights.semiBold};
   cursor: pointer;
   white-space: nowrap;
-  animation: ${ripple} 2s ease-out infinite;
+  animation: ${ripple} ${(props) => (props.$isUpdating ? '0.6s' : '2s')}
+    ease-out infinite;
   transition:
     background-color 0.15s ease,
     border-color 0.15s ease;
 
   .material-symbols-outlined {
     font-size: 14px !important;
+    ${(props) =>
+      props.$isUpdating &&
+      css`
+        animation: ${spin} 1s linear infinite;
+      `}
   }
 
   &:hover {
     background-color: ${theme.colors.backgroundLighter};
+  }
+
+  &:disabled {
+    cursor: default;
+    background-color: ${theme.colors.backgroundLight};
+    opacity: 0.95;
   }
 `;
 
@@ -49,17 +67,32 @@ const Chip = styled.button`
  * waiting to activate. A green ripple glow pulses outward to draw attention.
  * Clicking it reloads the page immediately, applying the update.
  */
-const UpdateChip = ({ onClick, 'data-testid': dataTestId }: Props) => (
-  <Chip
-    onClick={onClick}
-    aria-label="Update available — click to reload and apply"
-    data-testid={dataTestId ?? 'update-chip'}
-  >
-    <span className="material-symbols-outlined" aria-hidden="true">
-      update
-    </span>
-    Update Available
-  </Chip>
-);
+const UpdateChip = ({ onClick, 'data-testid': dataTestId }: Props) => {
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const handleClick = () => {
+    setIsUpdating(true);
+    onClick();
+  };
+
+  return (
+    <Chip
+      onClick={handleClick}
+      disabled={isUpdating}
+      $isUpdating={isUpdating}
+      aria-label={
+        isUpdating
+          ? 'Updating version...'
+          : 'Update available — click to reload and apply'
+      }
+      data-testid={dataTestId ?? 'update-chip'}
+    >
+      <span className="material-symbols-outlined" aria-hidden="true">
+        {isUpdating ? 'sync' : 'update'}
+      </span>
+      {isUpdating ? 'Updating version...' : 'Update Available'}
+    </Chip>
+  );
+};
 
 export default UpdateChip;

--- a/src/hooks/useServiceWorkerUpdate.test.ts
+++ b/src/hooks/useServiceWorkerUpdate.test.ts
@@ -31,6 +31,7 @@ describe('useServiceWorkerUpdate hook', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
 
     // Mock window.location
     mockReload = jest.fn();
@@ -57,6 +58,7 @@ describe('useServiceWorkerUpdate hook', () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     Object.defineProperty(global, 'navigator', {
       value: originalNavigator,
       writable: true,
@@ -145,6 +147,50 @@ describe('useServiceWorkerUpdate hook', () => {
     act(() => {
       registeredCallback();
     });
+    expect(mockReload).toHaveBeenCalledTimes(1);
+
+    // Fast-forward safety timeout; should not trigger another reload since it was cleared or already reloaded
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(mockReload).toHaveBeenCalledTimes(1);
+  });
+
+  it('should trigger reload via safety fallback timeout if controllerchange does not fire', () => {
+    const mockPostMessage = jest.fn();
+    const mockWaitingWorker = {
+      postMessage: mockPostMessage,
+    };
+    const mockRegistration = {
+      waiting: mockWaitingWorker,
+    } as unknown as ServiceWorkerRegistration;
+
+    let onUpdateCallback: any = null;
+    (serviceWorkerRegistration.register as jest.Mock).mockImplementation(
+      (config) => {
+        onUpdateCallback = config.onUpdate;
+      }
+    );
+
+    const { result } = renderHook(() => useServiceWorkerUpdate());
+
+    act(() => {
+      onUpdateCallback?.(mockRegistration);
+    });
+
+    expect(result.current).toBeInstanceOf(Function);
+
+    act(() => {
+      result.current?.();
+    });
+
+    expect(mockReload).not.toHaveBeenCalled();
+
+    // Advance fake timers by 1000ms
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
     expect(mockReload).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
### Description
This PR addresses an issue where clicking the "Update Available" chip could be unresponsive and fail to reload the page/apply the service worker update.

### Changes
1. **Safety Fallback Reload in `useServiceWorkerUpdate`**:
   - Implemented a 1-second fallback timeout that forces a page reload via `window.location.reload()` if the service worker's `controllerchange` event fails to fire after clicking update.
   - Clears the timeout if the event fires successfully before the timeout.
2. **Stateful Feedback in `UpdateChip`**:
   - Added `isUpdating` state to provide clear visual feedback to the user while the reload/update is in progress.
   - Updates text to "Updating version..." and icon to a rotating `sync` spinner.
   - Accelerates the pulsing green glow animation (0.6s instead of 2.0s) to indicate active update installation.
   - Disables the button to prevent duplicate click triggers.
3. **Tests & Docs**:
   - Added unit tests for the fallback timeout and `UpdateChip` visual updates.
   - Updated `DEVELOPMENT.md` to document the fallback behavior.
   - Bumped package version to `0.11.4`.