### PR TITLE
🧪 Add edge case tests for empty/invalid canonical objects in extractUsedInjectionsFromCanonical

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ergogen-gui",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "A web-based GUI for Ergogen, the ergonomic keyboard layout generator.",
   "license": "MIT",
   "private": false,

--- a/src/utils/share.test.ts
+++ b/src/utils/share.test.ts
@@ -683,6 +683,79 @@ describe('share utilities', () => {
       expect(result.outlines).toEqual(new Set());
     });
 
+    it('returns empty sets for undefined canonical', () => {
+      // Act
+      const result = extractUsedInjectionsFromCanonical(undefined);
+
+      // Assert
+      expect(result.footprints).toEqual(new Set());
+      expect(result.templates).toEqual(new Set());
+      expect(result.outlines).toEqual(new Set());
+    });
+
+    it('returns empty sets for empty object canonical', () => {
+      // Act
+      const result = extractUsedInjectionsFromCanonical({});
+
+      // Assert
+      expect(result.footprints).toEqual(new Set());
+      expect(result.templates).toEqual(new Set());
+      expect(result.outlines).toEqual(new Set());
+    });
+
+    it('returns empty sets for non-object primitive canonical values', () => {
+      // Act
+      const numResult = extractUsedInjectionsFromCanonical(123);
+      const strResult = extractUsedInjectionsFromCanonical('invalid');
+      const boolResult = extractUsedInjectionsFromCanonical(true);
+
+      // Assert
+      expect(numResult.footprints).toEqual(new Set());
+      expect(strResult.footprints).toEqual(new Set());
+      expect(boolResult.footprints).toEqual(new Set());
+    });
+
+    it('handles malformed pcbs and outlines sections gracefully', () => {
+      // Arrange: sections are defined but are not of the expected type (objects)
+      const canonical = {
+        pcbs: 'not-an-object',
+        outlines: 456,
+      };
+
+      // Act
+      const result = extractUsedInjectionsFromCanonical(canonical);
+
+      // Assert
+      expect(result.footprints).toEqual(new Set());
+      expect(result.templates).toEqual(new Set());
+      expect(result.outlines).toEqual(new Set());
+    });
+
+    it('skips malformed pcb configurations or outline structures', () => {
+      // Arrange: entries inside pcbs and outlines are primitive types or malformed structures
+      const canonical = {
+        pcbs: {
+          invalid_pcb: 'should-be-ignored',
+          valid_pcb: {
+            template: 789, // should be ignored (non-string)
+            footprints: 'invalid-footprints-format', // should be ignored (non-object)
+          },
+        },
+        outlines: {
+          invalid_outline: null, // should be ignored
+          another_invalid: 'not-an-object', // should be ignored
+        },
+      };
+
+      // Act
+      const result = extractUsedInjectionsFromCanonical(canonical);
+
+      // Assert
+      expect(result.footprints).toEqual(new Set());
+      expect(result.templates).toEqual(new Set());
+      expect(result.outlines).toEqual(new Set());
+    });
+
     it('returns empty sets when pcbs and outlines sections are absent', () => {
       // Arrange
       const canonical = { points: {}, units: {} };


### PR DESCRIPTION
### 🎯 **What:** The testing gap addressed
The testing gap addressed was the lack of unit tests for defensive fallback behaviors and error handling in `extractUsedInjectionsFromCanonical`. Specifically, tests were missing to verify that invalid, empty, or malformed canonical objects are parsed without throwing exceptions.

### 📊 **Coverage:** What scenarios are now tested
The following new edge cases and scenarios are now covered by unit tests:
* **Falsy/Undefined Inputs**: Verifies that passing `undefined` correctly yields empty injection sets.
* **Empty Object**: Verifies that passing `{}` returns empty sets gracefully.
* **Non-Object Primitives**: Verifies that invalid primitive inputs (e.g., number, string, boolean) return empty sets instead of failing.
* **Malformed Sections**: Verifies that when `pcbs` or `outlines` is defined as a non-object type (e.g. string or number), it is skipped safely.
* **Malformed Inner Objects**: Verifies that inner malformed items (e.g. non-object configurations in `pcbs`, invalid footprint types, non-string templates, or malformed outline entries) do not break parsing.

### ✨ **Result:** The improvement in test coverage
We've significantly improved the robust safety net around the sharing logic, ensuring that any external or unexpectedly formatted canonical object can be processed cleanly without crashing the share-packing flow.