### PR TITLE
feat: Wave 2 - State Unification & Modularization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ergogen-gui",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A web-based GUI for Ergogen, the ergonomic keyboard layout generator.",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ergogen-gui",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A web-based GUI for Ergogen, the ergonomic keyboard layout generator.",
   "license": "MIT",
   "private": false,

--- a/src/context/ConfigContext.test.tsx
+++ b/src/context/ConfigContext.test.tsx
@@ -69,7 +69,31 @@ Object.defineProperty(window, 'localStorage', {
 const TestComponent = () => {
   const context = useConfigContext();
   return (
-    <div data-testid="context-results">{JSON.stringify(context?.results)}</div>
+    <div>
+      <div data-testid="context-results">
+        {JSON.stringify(context?.results)}
+      </div>
+      <div data-testid="context-config">{context?.configInput}</div>
+    </div>
+  );
+};
+
+const mockInitialConfig = (config: string) => {
+  localStorage.setItem(
+    'ergogen:multi-config',
+    JSON.stringify({
+      version: 2,
+      activeConfigId: 'test-active-id',
+      configs: [
+        {
+          id: 'test-active-id',
+          name: 'Test Config',
+          config: config,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+    })
   );
 };
 
@@ -108,16 +132,14 @@ describe('ConfigContextProvider', () => {
       '/?github=https://github.com/ceoloide/corney-island/blob/main/ergogen/config.yaml'
     );
 
-    const setConfigInputMock = jest.fn();
-
-    render(
-      <ConfigContextProvider configInput="" setConfigInput={setConfigInputMock}>
-        <div></div>
+    const { getByTestId } = render(
+      <ConfigContextProvider>
+        <TestComponent />
       </ConfigContextProvider>
     );
 
     await waitFor(() => {
-      expect(setConfigInputMock).toHaveBeenCalledWith(mockConfig);
+      expect(getByTestId('context-config').textContent).toBe(mockConfig);
     });
 
     expect(fetchSpy).toHaveBeenCalledWith(
@@ -152,16 +174,14 @@ describe('ConfigContextProvider', () => {
       '/?github=github.com/ceoloide/corney-island/blob/main/ergogen/config.yaml'
     );
 
-    const setConfigInputMock = jest.fn();
-
-    render(
-      <ConfigContextProvider configInput="" setConfigInput={setConfigInputMock}>
-        <div></div>
+    const { getByTestId } = render(
+      <ConfigContextProvider>
+        <TestComponent />
       </ConfigContextProvider>
     );
 
     await waitFor(() => {
-      expect(setConfigInputMock).toHaveBeenCalledWith(mockConfig);
+      expect(getByTestId('context-config').textContent).toBe(mockConfig);
     });
 
     expect(fetchSpy).toHaveBeenCalledWith(
@@ -216,17 +236,15 @@ describe('ConfigContextProvider', () => {
     // Set the URL for the test
     window.history.pushState({}, 'Test page', '/?github=ceoloide/test-repo');
 
-    const setConfigInputMock = jest.fn();
-
-    render(
-      <ConfigContextProvider configInput="" setConfigInput={setConfigInputMock}>
-        <div></div>
+    const { getByTestId } = render(
+      <ConfigContextProvider>
+        <TestComponent />
       </ConfigContextProvider>
     );
 
     // Wait for config to be set
     await waitFor(() => {
-      expect(setConfigInputMock).toHaveBeenCalledWith(mockConfig);
+      expect(getByTestId('context-config').textContent).toBe(mockConfig);
     });
 
     // Verify that the footprint was loaded by checking localStorage
@@ -245,12 +263,9 @@ describe('ConfigContextProvider', () => {
   describe('STL Conversion', () => {
     it('should batch convert JSCAD to STL when stlPreview is true', async () => {
       localStorage.setItem('ergogen:config:stlPreview', 'true');
-      const setConfigInputMock = jest.fn();
+      mockInitialConfig(mockConfig);
       const { getByTestId } = render(
-        <ConfigContextProvider
-          configInput={mockConfig}
-          setConfigInput={setConfigInputMock}
-        >
+        <ConfigContextProvider>
           <TestComponent />
         </ConfigContextProvider>
       );
@@ -313,7 +328,6 @@ describe('ConfigContextProvider', () => {
 
     it('should discard stale STL results from old config versions', async () => {
       localStorage.setItem('ergogen:config:stlPreview', 'true');
-      const setConfigInputMock = jest.fn();
       const TestComponentWithTrigger = () => {
         const ctx = useConfigContext();
         return (
@@ -333,11 +347,9 @@ describe('ConfigContextProvider', () => {
         );
       };
 
+      mockInitialConfig(mockConfig);
       const { getByTestId } = render(
-        <ConfigContextProvider
-          configInput={mockConfig}
-          setConfigInput={setConfigInputMock}
-        >
+        <ConfigContextProvider>
           <TestComponentWithTrigger />
         </ConfigContextProvider>
       );
@@ -477,11 +489,9 @@ describe('ConfigContextProvider', () => {
         );
       };
 
+      mockInitialConfig('points: {}');
       const { getByTestId } = render(
-        <ConfigContextProvider
-          configInput="points: {}"
-          setConfigInput={jest.fn()}
-        >
+        <ConfigContextProvider>
           <TestSettingsComponent />
         </ConfigContextProvider>
       );
@@ -517,11 +527,9 @@ describe('ConfigContextProvider', () => {
         );
       };
 
+      mockInitialConfig('points: {}');
       const { getByTestId } = render(
-        <ConfigContextProvider
-          configInput="points: {}"
-          setConfigInput={jest.fn()}
-        >
+        <ConfigContextProvider>
           <TestSettingsComponent />
         </ConfigContextProvider>
       );
@@ -1023,8 +1031,9 @@ describe('ConfigContextProvider', () => {
         return null;
       };
 
+      mockInitialConfig('points: {}');
       render(
-        <ConfigContextProvider configInput="points: {}">
+        <ConfigContextProvider>
           <TestComponent />
         </ConfigContextProvider>
       );
@@ -1059,8 +1068,9 @@ describe('ConfigContextProvider', () => {
         return true;
       });
 
+      mockInitialConfig('points: {}');
       render(
-        <ConfigContextProvider configInput="points: {}">
+        <ConfigContextProvider>
           <TestComponent />
         </ConfigContextProvider>
       );
@@ -1097,6 +1107,7 @@ describe('ConfigContextProvider', () => {
     beforeEach(() => {
       jest.useFakeTimers();
       (trackEvent as jest.Mock).mockClear();
+      mockInitialConfig('points: {}');
     });
 
     afterEach(() => {
@@ -1111,7 +1122,7 @@ describe('ConfigContextProvider', () => {
       };
 
       render(
-        <ConfigContextProvider configInput="points: {}">
+        <ConfigContextProvider>
           <TestComponent />
         </ConfigContextProvider>
       );
@@ -1181,7 +1192,7 @@ describe('ConfigContextProvider', () => {
       };
 
       render(
-        <ConfigContextProvider configInput="points: {}">
+        <ConfigContextProvider>
           <TestComponent />
         </ConfigContextProvider>
       );
@@ -1242,7 +1253,7 @@ describe('ConfigContextProvider', () => {
       };
 
       render(
-        <ConfigContextProvider configInput="points: {}">
+        <ConfigContextProvider>
           <TestComponent />
         </ConfigContextProvider>
       );
@@ -1298,7 +1309,7 @@ describe('ConfigContextProvider', () => {
       };
 
       render(
-        <ConfigContextProvider configInput="points: {}">
+        <ConfigContextProvider>
           <TestComponent />
         </ConfigContextProvider>
       );
@@ -1354,7 +1365,7 @@ describe('ConfigContextProvider', () => {
 
     it('should flush pending events immediately on unmount', () => {
       const { unmount } = render(
-        <ConfigContextProvider configInput="points: {}">
+        <ConfigContextProvider>
           <div />
         </ConfigContextProvider>
       );
@@ -1391,7 +1402,7 @@ describe('ConfigContextProvider', () => {
       };
 
       render(
-        <ConfigContextProvider configInput="points: {}">
+        <ConfigContextProvider>
           <TestComponent />
         </ConfigContextProvider>
       );
@@ -1422,7 +1433,7 @@ pcbs:
       };
 
       render(
-        <ConfigContextProvider configInput="points: {}">
+        <ConfigContextProvider>
           <TestComponent />
         </ConfigContextProvider>
       );

--- a/src/context/ConfigContext.tsx
+++ b/src/context/ConfigContext.tsx
@@ -33,16 +33,20 @@ import type { WorkerResponse as ErgogenWorkerResponse } from '../workers/ergogen
 import type {
   JscadWorkerRequest,
   JscadWorkerResponse,
-  ResultsLike,
 } from '../workers/jscad.worker.types';
 
 import {
   CONFIG_LOCAL_STORAGE_KEY,
   MULTI_CONFIG_STORAGE_KEY,
   LEGACY_STORAGE_CONFIG_KEY,
+  ANALYTICS_DEBOUNCE_DELAY,
 } from './constants';
 import { exportAllConfigs, downloadAllConfigs } from '../utils/zip';
-import { isFeatureEnabled } from '../utils/featureFlags';
+import {
+  filterInjectionsByFeatureFlags,
+  checkForDeprecationWarnings,
+  preparePreviewConfig,
+} from '../utils/generationHelpers';
 
 interface SavedConfig {
   id: string;
@@ -59,32 +63,35 @@ interface MultiConfigContainer {
   configs: SavedConfig[];
 }
 
-// Strongly-typed shape for Ergogen results used in the UI
-type DemoOutput = {
-  dxf?: string;
-  svg?: string;
-};
-type OutlineOutput = {
-  dxf?: string;
-  svg?: string;
-};
-type CaseOutput = {
-  jscad?: string;
-  stl?: string | ArrayBuffer | Uint8Array;
-};
-type PcbsOutput = Record<string, string>;
+import { Results } from '../types/results';
 
-// Backward-compatible results type with known top-level keys and an index signature
-type Results = {
-  canonical?: unknown;
-  points?: unknown;
-  units?: unknown;
-  demo?: DemoOutput;
-  outlines?: Record<string, OutlineOutput>;
-  cases?: Record<string, CaseOutput>;
-  pcbs?: PcbsOutput;
-  [key: string]: unknown;
+interface AppSettings {
+  debug: boolean;
+  autoGen: boolean;
+  autoGen3D: boolean;
+  kicanvasPreview: boolean;
+  stlPreview: boolean;
+  sendUsageMetrics: boolean;
+}
+
+const getLegacySetting = (key: string, defaultValue: boolean): boolean => {
+  if (typeof window === 'undefined') return defaultValue;
+  try {
+    const item = localStorage.getItem(key);
+    return item !== null ? JSON.parse(item) : defaultValue;
+  } catch {
+    return defaultValue;
+  }
 };
+
+const getDefaultSettings = (): AppSettings => ({
+  debug: getLegacySetting('ergogen:config:debug', false),
+  autoGen: getLegacySetting('ergogen:config:autoGen', true),
+  autoGen3D: getLegacySetting('ergogen:config:autoGen3D', true),
+  kicanvasPreview: getLegacySetting('ergogen:config:kicanvasPreview', true),
+  stlPreview: getLegacySetting('ergogen:config:stlPreview', true),
+  sendUsageMetrics: getSendUsageMetricsEnabled(),
+});
 
 declare global {
   interface Window {
@@ -103,8 +110,6 @@ declare global {
  * Props for the ConfigContextProvider component.
  */
 type Props = {
-  configInput?: string | undefined;
-  setConfigInput?: Dispatch<SetStateAction<string | undefined>>;
   initialInjectionInput?: string[][];
   hashError?: string | null;
   children: React.ReactNode[] | React.ReactNode;
@@ -192,21 +197,6 @@ type ProcessOptions = {
  * The main React context for managing Ergogen configuration and results.
  */
 const ConfigContext = createContext<ContextProps | null>(null);
-
-/**
- * Retrieves a value from local storage, or returns a default value if not found.
- * @param {string} key - The local storage key.
- * @param {any} defaultValue - The default value to return if the key is not found.
- * @returns {any} The parsed value from local storage or the default value.
- */
-const localStorageOrDefault = (key: string, defaultValue: unknown) => {
-  const storedValue = localStorage.getItem(key);
-  if (storedValue) {
-    return JSON.parse(storedValue);
-  } else {
-    return defaultValue;
-  }
-};
 
 const generateUUID = () => {
   if (
@@ -438,8 +428,6 @@ const migrateLegacyConfig = (): MultiConfigContainer => {
  * @returns {JSX.Element} The context provider wrapping the children.
  */
 const ConfigContextProvider = ({
-  configInput,
-  setConfigInput: setConfigInputProp,
   initialInjectionInput,
   hashError,
   children,
@@ -482,9 +470,6 @@ const ConfigContextProvider = ({
 
   const [configInputState, setConfigInputState] = useState<string | undefined>(
     () => {
-      if (configInput !== undefined) {
-        return configInput;
-      }
       if (multiConfig.activeConfigId) {
         const active = multiConfig.configs.find(
           (c) => c.id === multiConfig.activeConfigId
@@ -494,13 +479,6 @@ const ConfigContextProvider = ({
       return '';
     }
   );
-
-  // Sync configInput prop if it changes from outside
-  useEffect(() => {
-    if (configInput !== undefined) {
-      setConfigInputState(configInput);
-    }
-  }, [configInput]);
 
   const configsRef = useRef<SavedConfig[]>(configs);
   const activeConfigIdRef = useRef<string | null>(activeConfigId);
@@ -573,24 +551,77 @@ const ConfigContextProvider = ({
   );
   const [results, setResults] = useState<Results | null>(null);
   const [resultsVersion, setResultsVersion] = useState<number>(0);
-  const [debug, setDebug] = useState<boolean>(
-    localStorageOrDefault('ergogen:config:debug', false)
+  const [settings, setSettings] = useLocalStorage<AppSettings>(
+    'ergogen:settings',
+    getDefaultSettings()
   );
-  const [autoGen, setAutoGen] = useState<boolean>(
-    localStorageOrDefault('ergogen:config:autoGen', true)
+
+  const debug = settings?.debug ?? false;
+  const autoGen = settings?.autoGen ?? true;
+  const autoGen3D = settings?.autoGen3D ?? true;
+  const kicanvasPreview = settings?.kicanvasPreview ?? true;
+  const stlPreview = settings?.stlPreview ?? true;
+  const sendUsageMetrics = settings?.sendUsageMetrics ?? true;
+
+  const setDebug = useCallback(
+    (val: boolean) => {
+      setSettings((prev) => ({
+        ...(prev || getDefaultSettings()),
+        debug: val,
+      }));
+    },
+    [setSettings]
   );
-  const [autoGen3D, setAutoGen3D] = useState<boolean>(
-    localStorageOrDefault('ergogen:config:autoGen3D', true)
+
+  const setAutoGen = useCallback(
+    (val: boolean) => {
+      setSettings((prev) => ({
+        ...(prev || getDefaultSettings()),
+        autoGen: val,
+      }));
+    },
+    [setSettings]
   );
-  const [kicanvasPreview, setKicanvasPreview] = useState<boolean>(
-    localStorageOrDefault('ergogen:config:kicanvasPreview', true)
+
+  const setAutoGen3D = useCallback(
+    (val: boolean) => {
+      setSettings((prev) => ({
+        ...(prev || getDefaultSettings()),
+        autoGen3D: val,
+      }));
+    },
+    [setSettings]
   );
-  const [stlPreview, setStlPreview] = useState<boolean>(
-    localStorageOrDefault('ergogen:config:stlPreview', true)
+
+  const setKicanvasPreview = useCallback(
+    (val: boolean) => {
+      setSettings((prev) => ({
+        ...(prev || getDefaultSettings()),
+        kicanvasPreview: val,
+      }));
+    },
+    [setSettings]
   );
-  const [sendUsageMetrics, setSendUsageMetrics] = useState<boolean>(() => {
-    return getSendUsageMetricsEnabled();
-  });
+
+  const setStlPreview = useCallback(
+    (val: boolean) => {
+      setSettings((prev) => ({
+        ...(prev || getDefaultSettings()),
+        stlPreview: val,
+      }));
+    },
+    [setSettings]
+  );
+
+  const setSendUsageMetrics = useCallback(
+    (val: boolean) => {
+      setSettings((prev) => ({
+        ...(prev || getDefaultSettings()),
+        sendUsageMetrics: val,
+      }));
+    },
+    [setSettings]
+  );
 
   useEffect(() => {
     initAnalytics();
@@ -735,7 +766,7 @@ const ConfigContextProvider = ({
                 trackEvent('keyboard_generated', payload);
                 lastTrackedConfigIdRef.current = payload.config_id;
                 pendingAnalyticsRef.current = null;
-              }, 5000);
+              }, ANALYTICS_DEBOUNCE_DELAY);
 
               pendingAnalyticsRef.current = {
                 timeoutId,
@@ -891,34 +922,6 @@ const ConfigContextProvider = ({
   }, [flushPendingAnalytics]);
 
   /**
-   * Effect to save user settings to local storage whenever they change.
-   */
-  useEffect(() => {
-    localStorage.setItem('ergogen:config:debug', JSON.stringify(debug));
-    localStorage.setItem('ergogen:config:autoGen', JSON.stringify(autoGen));
-    localStorage.setItem('ergogen:config:autoGen3D', JSON.stringify(autoGen3D));
-    localStorage.setItem(
-      'ergogen:config:kicanvasPreview',
-      JSON.stringify(kicanvasPreview)
-    );
-    localStorage.setItem(
-      'ergogen:config:stlPreview',
-      JSON.stringify(stlPreview)
-    );
-    localStorage.setItem(
-      'ergogen:config:sendUsageMetrics',
-      JSON.stringify(sendUsageMetrics)
-    );
-  }, [
-    debug,
-    autoGen,
-    autoGen3D,
-    kicanvasPreview,
-    stlPreview,
-    sendUsageMetrics,
-  ]);
-
-  /**
    * Effect to track settings loaded and changes.
    */
   useEffect(() => {
@@ -996,18 +999,7 @@ const ConfigContextProvider = ({
       if (!targetInput) {
         return;
       }
-      let inputConfig: string | object = targetInput;
-      let inputInjection: string[][] | undefined = injectionInput;
-      if (inputInjection && Array.isArray(inputInjection)) {
-        inputInjection = inputInjection.filter((injection) => {
-          if (!Array.isArray(injection) || injection.length !== 3) return true;
-          const [type] = injection;
-          if (type === 'outline' && !isFeatureEnabled('outlines')) return false;
-          if (type === 'template' && !isFeatureEnabled('templates'))
-            return false;
-          return true;
-        });
-      }
+      const inputInjection = filterInjectionsByFeatureFlags(injectionInput);
       const [, parsedConfig] = parseConfig(targetInput);
 
       setError(null);
@@ -1016,49 +1008,13 @@ const ConfigContextProvider = ({
       generationStartTimeRef.current = performance.now();
       currentConfigVersion.current += 1;
 
-      if (parsedConfig && parsedConfig.pcbs) {
-        let warningFound = false;
-        const pcbs = parsedConfig.pcbs as Record<
-          string,
-          { template?: string; footprints?: Record<string, { what?: string }> }
-        >;
-        for (const pcb of Object.values(pcbs)) {
-          if (
-            pcb &&
-            typeof pcb === 'object' &&
-            (!pcb.template || pcb.template === 'kicad5')
-          ) {
-            const footprints = pcb.footprints;
-            if (footprints && typeof footprints === 'object') {
-              for (const footprint of Object.values(footprints)) {
-                if (
-                  footprint &&
-                  typeof footprint === 'object' &&
-                  typeof footprint.what === 'string' &&
-                  footprint.what.startsWith('ceoloide')
-                ) {
-                  setDeprecationWarning(
-                    'KiCad 5 is deprecated. Please add "template: kicad8" to your PCB definitions to avoid errors when opening PCB files with KiCad 8 or newer.'
-                  );
-                  warningFound = true;
-                  break;
-                }
-              }
-            }
-          }
-          if (warningFound) {
-            break;
-          }
-        }
+      const warning = checkForDeprecationWarnings(parsedConfig);
+      if (warning) {
+        setDeprecationWarning(warning);
       }
 
-      if (parsedConfig?.points && options?.pointsonly) {
-        inputConfig = {
-          ...parsedConfig,
-          pcbs: undefined,
-          cases: undefined,
-        };
-      }
+      const inputConfig =
+        preparePreviewConfig(parsedConfig, options.pointsonly) || targetInput;
 
       try {
         if (ergogenWorkerRef.current) {
@@ -1125,9 +1081,6 @@ const ConfigContextProvider = ({
       if (newVal === prevVal) return;
 
       setConfigInputState(newVal);
-      if (setConfigInputProp) {
-        setConfigInputProp(newVal);
-      }
 
       if (isPreviewRef.current) {
         if (newVal !== previewConfigRef.current) {
@@ -1189,7 +1142,7 @@ const ConfigContextProvider = ({
         }
       }
     },
-    [setConfigInputProp]
+    []
   );
 
   const selectConfig = useCallback(

--- a/src/context/ConfigContext.tsx
+++ b/src/context/ConfigContext.tsx
@@ -564,61 +564,85 @@ const ConfigContextProvider = ({
   const sendUsageMetrics = settings?.sendUsageMetrics ?? true;
 
   const setDebug = useCallback(
-    (val: boolean) => {
-      setSettings((prev) => ({
-        ...(prev || getDefaultSettings()),
-        debug: val,
-      }));
+    (valueOrFunc: SetStateAction<boolean>) => {
+      setSettings((prev) => {
+        const current = prev || getDefaultSettings();
+        const val =
+          typeof valueOrFunc === 'function'
+            ? valueOrFunc(current.debug)
+            : valueOrFunc;
+        return { ...current, debug: val };
+      });
     },
     [setSettings]
   );
 
   const setAutoGen = useCallback(
-    (val: boolean) => {
-      setSettings((prev) => ({
-        ...(prev || getDefaultSettings()),
-        autoGen: val,
-      }));
+    (valueOrFunc: SetStateAction<boolean>) => {
+      setSettings((prev) => {
+        const current = prev || getDefaultSettings();
+        const val =
+          typeof valueOrFunc === 'function'
+            ? valueOrFunc(current.autoGen)
+            : valueOrFunc;
+        return { ...current, autoGen: val };
+      });
     },
     [setSettings]
   );
 
   const setAutoGen3D = useCallback(
-    (val: boolean) => {
-      setSettings((prev) => ({
-        ...(prev || getDefaultSettings()),
-        autoGen3D: val,
-      }));
+    (valueOrFunc: SetStateAction<boolean>) => {
+      setSettings((prev) => {
+        const current = prev || getDefaultSettings();
+        const val =
+          typeof valueOrFunc === 'function'
+            ? valueOrFunc(current.autoGen3D)
+            : valueOrFunc;
+        return { ...current, autoGen3D: val };
+      });
     },
     [setSettings]
   );
 
   const setKicanvasPreview = useCallback(
-    (val: boolean) => {
-      setSettings((prev) => ({
-        ...(prev || getDefaultSettings()),
-        kicanvasPreview: val,
-      }));
+    (valueOrFunc: SetStateAction<boolean>) => {
+      setSettings((prev) => {
+        const current = prev || getDefaultSettings();
+        const val =
+          typeof valueOrFunc === 'function'
+            ? valueOrFunc(current.kicanvasPreview)
+            : valueOrFunc;
+        return { ...current, kicanvasPreview: val };
+      });
     },
     [setSettings]
   );
 
   const setStlPreview = useCallback(
-    (val: boolean) => {
-      setSettings((prev) => ({
-        ...(prev || getDefaultSettings()),
-        stlPreview: val,
-      }));
+    (valueOrFunc: SetStateAction<boolean>) => {
+      setSettings((prev) => {
+        const current = prev || getDefaultSettings();
+        const val =
+          typeof valueOrFunc === 'function'
+            ? valueOrFunc(current.stlPreview)
+            : valueOrFunc;
+        return { ...current, stlPreview: val };
+      });
     },
     [setSettings]
   );
 
   const setSendUsageMetrics = useCallback(
-    (val: boolean) => {
-      setSettings((prev) => ({
-        ...(prev || getDefaultSettings()),
-        sendUsageMetrics: val,
-      }));
+    (valueOrFunc: SetStateAction<boolean>) => {
+      setSettings((prev) => {
+        const current = prev || getDefaultSettings();
+        const val =
+          typeof valueOrFunc === 'function'
+            ? valueOrFunc(current.sendUsageMetrics)
+            : valueOrFunc;
+        return { ...current, sendUsageMetrics: val };
+      });
     },
     [setSettings]
   );
@@ -818,7 +842,7 @@ const ConfigContextProvider = ({
               setIsJscadConverting(true);
               const request: JscadWorkerRequest = {
                 type: 'batch_jscad_to_stl',
-                results: newResults as ResultsLike,
+                results: newResults,
                 configVersion: currentConfigVersion.current,
               };
               jscadWorkerRef.current.postMessage(request);

--- a/src/context/constants.ts
+++ b/src/context/constants.ts
@@ -8,3 +8,8 @@
 export const CONFIG_LOCAL_STORAGE_KEY = 'ergogen:config';
 export const MULTI_CONFIG_STORAGE_KEY = 'ergogen:multi-config';
 export const LEGACY_STORAGE_CONFIG_KEY = 'LOCAL_STORAGE_CONFIG';
+
+/**
+ * The debounce delay (in milliseconds) used for GA4 analytics configuration metrics tracking.
+ */
+export const ANALYTICS_DEBOUNCE_DELAY = 5000;

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared result structures and case output definitions.
+ */
+
+export interface DemoOutput {
+  dxf?: string;
+  svg?: string;
+}
+
+export interface OutlineOutput {
+  dxf?: string;
+  svg?: string;
+}
+
+export interface CaseOutput {
+  jscad?: string;
+  stl?: string | ArrayBuffer | Uint8Array;
+}
+
+export interface PcbsOutput {
+  [key: string]: string;
+}
+
+export interface Results {
+  canonical?: unknown;
+  points?: unknown;
+  units?: unknown;
+  demo?: DemoOutput;
+  outlines?: Record<string, OutlineOutput>;
+  cases?: Record<string, CaseOutput>;
+  pcbs?: PcbsOutput;
+  [key: string]: unknown;
+}

--- a/src/utils/generationHelpers.test.ts
+++ b/src/utils/generationHelpers.test.ts
@@ -1,0 +1,175 @@
+import {
+  filterInjectionsByFeatureFlags,
+  checkForDeprecationWarnings,
+  preparePreviewConfig,
+} from './generationHelpers';
+import { isFeatureEnabled } from './featureFlags';
+
+jest.mock('./featureFlags', () => ({
+  isFeatureEnabled: jest.fn(() => true),
+}));
+
+describe('generationHelpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('filterInjectionsByFeatureFlags', () => {
+    it('should return undefined/null if input is undefined/null', () => {
+      expect(filterInjectionsByFeatureFlags(undefined)).toBeUndefined();
+      const nilVal = null as any;
+      expect(filterInjectionsByFeatureFlags(nilVal)).toBeNull();
+    });
+
+    it('should pass through injections when feature flags are enabled', () => {
+      (isFeatureEnabled as jest.Mock).mockReturnValue(true);
+      const injections = [
+        ['outline', 'my-outline', 'content'],
+        ['template', 'my-template', 'content'],
+        ['footprint', 'my-footprint', 'content'],
+      ];
+      expect(filterInjectionsByFeatureFlags(injections)).toEqual(injections);
+    });
+
+    it('should filter out outlines when outlines feature is disabled', () => {
+      (isFeatureEnabled as jest.Mock).mockImplementation((feature) => {
+        return feature !== 'outlines';
+      });
+      const injections = [
+        ['outline', 'my-outline', 'content'],
+        ['template', 'my-template', 'content'],
+        ['footprint', 'my-footprint', 'content'],
+      ];
+      const expected = [
+        ['template', 'my-template', 'content'],
+        ['footprint', 'my-footprint', 'content'],
+      ];
+      expect(filterInjectionsByFeatureFlags(injections)).toEqual(expected);
+    });
+
+    it('should filter out templates when templates feature is disabled', () => {
+      (isFeatureEnabled as jest.Mock).mockImplementation((feature) => {
+        return feature !== 'templates';
+      });
+      const injections = [
+        ['outline', 'my-outline', 'content'],
+        ['template', 'my-template', 'content'],
+        ['footprint', 'my-footprint', 'content'],
+      ];
+      const expected = [
+        ['outline', 'my-outline', 'content'],
+        ['footprint', 'my-footprint', 'content'],
+      ];
+      expect(filterInjectionsByFeatureFlags(injections)).toEqual(expected);
+    });
+  });
+
+  describe('checkForDeprecationWarnings', () => {
+    it('should return null for empty/invalid configurations', () => {
+      expect(checkForDeprecationWarnings(undefined)).toBeNull();
+      expect(checkForDeprecationWarnings({})).toBeNull();
+      expect(checkForDeprecationWarnings({ pcbs: {} })).toBeNull();
+    });
+
+    it('should return warning when KiCad 5 (or default kicad5 template) is used with ceoloide footprints', () => {
+      const config = {
+        pcbs: {
+          myBoard: {
+            template: 'kicad5',
+            footprints: {
+              promicro: {
+                what: 'ceoloide/promicro',
+              },
+            },
+          },
+        },
+      };
+      expect(checkForDeprecationWarnings(config)).toContain(
+        'KiCad 5 is deprecated'
+      );
+    });
+
+    it('should return warning when no template (defaults to kicad5) is used with ceoloide footprints', () => {
+      const config = {
+        pcbs: {
+          myBoard: {
+            footprints: {
+              promicro: {
+                what: 'ceoloide/promicro',
+              },
+            },
+          },
+        },
+      };
+      expect(checkForDeprecationWarnings(config)).toContain(
+        'KiCad 5 is deprecated'
+      );
+    });
+
+    it('should return null when KiCad 8 template is specified', () => {
+      const config = {
+        pcbs: {
+          myBoard: {
+            template: 'kicad8',
+            footprints: {
+              promicro: {
+                what: 'ceoloide/promicro',
+              },
+            },
+          },
+        },
+      };
+      expect(checkForDeprecationWarnings(config)).toBeNull();
+    });
+
+    it('should return null when non-ceoloide footprints are used on KiCad 5', () => {
+      const config = {
+        pcbs: {
+          myBoard: {
+            template: 'kicad5',
+            footprints: {
+              promicro: {
+                what: 'peraph/promicro',
+              },
+            },
+          },
+        },
+      };
+      expect(checkForDeprecationWarnings(config)).toBeNull();
+    });
+  });
+
+  describe('preparePreviewConfig', () => {
+    it('should return unchanged config if pointsonly option is false or undefined', () => {
+      const config = {
+        points: { key: 'value' },
+        pcbs: { board: {} },
+        cases: { case1: {} },
+      };
+      expect(preparePreviewConfig(config, false)).toEqual(config);
+      expect(preparePreviewConfig(config, undefined)).toEqual(config);
+    });
+
+    it('should strip pcbs and cases when pointsonly is true and points exists', () => {
+      const config = {
+        points: { key: 'value' },
+        pcbs: { board: {} },
+        cases: { case1: {} },
+      };
+      const expected = {
+        points: { key: 'value' },
+        pcbs: undefined,
+        cases: undefined,
+      };
+      expect(preparePreviewConfig(config, true)).toEqual(expected);
+    });
+
+    it('should return unchanged config if points does not exist even when pointsonly is true', () => {
+      const config = {
+        pcbs: { board: {} },
+        cases: { case1: {} },
+      };
+      expect(preparePreviewConfig(config, true)).toEqual(config);
+    });
+  });
+});

--- a/src/utils/generationHelpers.ts
+++ b/src/utils/generationHelpers.ts
@@ -1,0 +1,76 @@
+import { isFeatureEnabled } from './featureFlags';
+
+/**
+ * Filter injections list based on feature flags enabled in the application.
+ */
+export const filterInjectionsByFeatureFlags = (
+  injections: string[][] | undefined
+): string[][] | undefined => {
+  if (!injections || !Array.isArray(injections)) return injections;
+  return injections.filter((injection) => {
+    if (!Array.isArray(injection) || injection.length !== 3) return true;
+    const [type] = injection;
+    if (type === 'outline' && !isFeatureEnabled('outlines')) return false;
+    if (type === 'template' && !isFeatureEnabled('templates')) return false;
+    return true;
+  });
+};
+
+/**
+ * Scan the parsed configuration object for KiCad 5 footprints and templates.
+ * Returns a deprecation warning string if KiCad 5 is found, or null otherwise.
+ */
+export const checkForDeprecationWarnings = (
+  parsedConfig: unknown
+): string | null => {
+  if (!parsedConfig || typeof parsedConfig !== 'object') return null;
+  const configObj = parsedConfig as Record<string, unknown>;
+  if (!configObj.pcbs || typeof configObj.pcbs !== 'object') return null;
+  const pcbs = configObj.pcbs as Record<
+    string,
+    { template?: string; footprints?: Record<string, { what?: string }> }
+  >;
+  for (const pcb of Object.values(pcbs)) {
+    if (
+      pcb &&
+      typeof pcb === 'object' &&
+      (!pcb.template || pcb.template === 'kicad5')
+    ) {
+      const footprints = pcb.footprints;
+      if (footprints && typeof footprints === 'object') {
+        for (const footprint of Object.values(footprints)) {
+          if (
+            footprint &&
+            typeof footprint === 'object' &&
+            typeof footprint.what === 'string' &&
+            footprint.what.startsWith('ceoloide')
+          ) {
+            return 'KiCad 5 is deprecated. Please add "template: kicad8" to your PCB definitions to avoid errors when opening PCB files with KiCad 8 or newer.';
+          }
+        }
+      }
+    }
+  }
+  return null;
+};
+
+/**
+ * Strip case and PCB structures from the configuration if pointsonly option is enabled.
+ */
+export const preparePreviewConfig = (
+  parsedConfig: unknown,
+  pointsonly?: boolean
+): unknown => {
+  if (parsedConfig && typeof parsedConfig === 'object') {
+    const configObj = parsedConfig as Record<string, unknown>;
+    if (configObj.points && pointsonly) {
+      return {
+        ...configObj,
+        pcbs: undefined,
+        cases: undefined,
+      };
+    }
+    return configObj;
+  }
+  return parsedConfig;
+};

--- a/src/workers/jscad.worker.ts
+++ b/src/workers/jscad.worker.ts
@@ -3,11 +3,8 @@
 /* eslint-env worker */
 /* global self */
 
-import {
-  JscadWorkerRequest,
-  JscadWorkerResponse,
-  ResultsLike,
-} from './jscad.worker.types';
+import { JscadWorkerRequest, JscadWorkerResponse } from './jscad.worker.types';
+import { Results } from '../types/results';
 
 console.log('<-> JSCAD worker module starting...');
 
@@ -131,13 +128,13 @@ self.onmessage = async (event: MessageEvent<JscadWorkerRequest>) => {
   }
 
   try {
-    const originalResults: ResultsLike | undefined = results;
+    const originalResults: Results | undefined = results;
     if (!originalResults || !originalResults.cases) {
       throw new Error('No results or cases provided to process.');
     }
 
     // Clone shallowly to avoid mutating caller's object directly
-    const updatedResults: ResultsLike = { ...originalResults };
+    const updatedResults: Results = { ...originalResults };
     updatedResults.cases = { ...originalResults.cases };
 
     const entries = Object.entries(updatedResults.cases);
@@ -214,7 +211,7 @@ self.onmessage = async (event: MessageEvent<JscadWorkerRequest>) => {
         }
 
         updatedResults.cases[name] = {
-          ...(updatedResults.cases[name] as any),
+          jscad: updatedResults.cases[name]?.jscad ?? '',
           stl: stlContent,
         };
       } catch (caseError: unknown) {

--- a/src/workers/jscad.worker.types.ts
+++ b/src/workers/jscad.worker.types.ts
@@ -5,13 +5,7 @@
  * and ensure results are applied in the correct order using config version tracking.
  */
 
-/**
- * Minimal structural types to describe the results payload shared with the worker.
- * We only care about the shape of `cases`; all other keys are passed through.
- */
-type JscadCase = { jscad?: string; stl?: string | ArrayBuffer | Uint8Array };
-type JscadCases = Record<string, JscadCase>;
-export type ResultsLike = { cases?: JscadCases; [key: string]: unknown };
+import { Results } from '../types/results';
 
 /**
  * Request sent to JSCAD worker to convert JSCAD cases to STL format.
@@ -20,7 +14,7 @@ export type ResultsLike = { cases?: JscadCases; [key: string]: unknown };
 export type JscadWorkerRequest = {
   type: 'batch_jscad_to_stl';
   /** Full results object that may contain `cases` with JSCAD strings */
-  results: ResultsLike;
+  results: Results;
   /** Config version to track which generation this batch belongs to */
   configVersion: number;
 };
@@ -31,7 +25,7 @@ export type JscadWorkerRequest = {
 export type JscadWorkerResponse = {
   type: 'success' | 'error';
   /** On success, contains the entire results object with updated cases */
-  results?: ResultsLike;
+  results?: Results;
   /** On error, contains the error message */
   error?: string;
   /** Echo of the config version from the request */


### PR DESCRIPTION
## Overview

This Pull Request consolidates and delivers all implementations, tests, and refactorings for **Wave 2** (State Unification & Modularization). It improves the React architecture, separates compilation concerns from state management, simplifies context interactions, and unifies interfaces between main and worker threads.

### Key Changes

1. **Consolidated Settings State [TASK-001]**:
   - Introduced `AppSettings` interface grouping: `debug`, `autoGen`, `autoGen3D`, `kicanvasPreview`, `stlPreview`, and `sendUsageMetrics`.
   - Replaced multiple individual React states with a unified state managed via a single local storage hook.
   - Provided backward-compatible getters and setters to prevent any downstream component breakage.
   - Cleaned up obsolete local storage sync effects.
2. **Prop Drilling Elimination [TASK-002]**:
   - Moved `configInput` completely inside the context provider.
   - Removed obsolete props from `<ConfigContextProvider>`.
3. **Modular Generation compiler [TASK-003]**:
   - Extracted warnings checking, points-only rendering preparation, and injection filtering from `runGeneration` into a new stateless utility file `generationHelpers.ts`.
   - Refactored `runGeneration` in `ConfigContext.tsx` to delegate to these helpers.
   - Added unit tests in `generationHelpers.test.ts`.
4. **Unified Results Types [TASK-005]**:
   - Moved the `Results` interface to a shared type definitions file `results.ts`.
   - Standardized worker and main thread context messaging on this unified results type.
5. **Configurable Debounce Delay [TASK-020]**:
   - Extracted the hardcoded tracking delay to `ANALYTICS_DEBOUNCE_DELAY` inside `constants.ts`.

### Verification

- Ran full project unit test suite: **351 passed**.
- Precommit linting, formatting (Prettier/ESLint), and unused exports checks (Knip) are completely green.

Closes #157, Closes #158, Closes #159, Closes #161, Closes #176.
