### PR TITLE
feat: Wave 3 - Unified Bundle Loader, Size Limits, Welcome UI, Restructured Outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unified Ergogen Bundle Loader and REST Directory Restructuring
+
+July 15, 2026
+
+![A diagram representing the unified loading pipelines and restructured archive outputs.](./public/images/changelog/placeholder.png)
+
+Previously, loading custom Ergogen configurations and injection files (footprints, outlines, and templates) from ZIP/EKB archives or GitHub repositories was handled by duplicate, ad-hoc validation and parsing logic. Additionally, exported output files (PCBs, outlines, cases, etc.) were placed at the root of generated archives, causing folder namespace conflicts with input injection folders (specifically `outlines/`).
+
+To resolve this, we introduced a unified [ergogenBundleLoader.ts](file:///Users/mmassarelli/Documents/GitHub/ergogen-gui/src/utils/ergogenBundleLoader.ts) library that centralizes archive extraction, structure validation, file size limits (50MB for archives, 10MB for text configs), and injection projection. The Welcome page was updated to provide visual spinner indicators, disable concurrent input interactions, and display counts of loaded components in a global notification banner. Lastly, the ZIP generation pipeline was restructured to write all generated outputs under an `outputs/` subdirectory, completely resolving naming collisions. We have also bumped the version to 0.15.0.
+
+**What changed:**
+
+- **Centralized Bundle Loader**: Created `ergogenBundleLoader.ts` to host unified validation, file size enforcement, and zip extraction logic.
+- **Visual Loading Indicators**: Integrated spinner animations inside Welcome page action buttons and disabled dropped input interactions during loading.
+- **REST Outputs Restructuring**: Modified the ZIP exporter to store all generated compilation outputs under an `outputs/` directory inside exported archives.
+- **In-App Load Summaries**: Introduced a global info banner to display a summary of loaded custom libraries.
+- **Version Bump**: Updates the application version to 0.15.0.
+
 ## End-to-End Binary STL Export and Preview Pipeline
 
 July 15, 2026

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ergogen-gui",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "A web-based GUI for Ergogen, the ergonomic keyboard layout generator.",
   "license": "MIT",
   "private": false,

--- a/src/context/ConfigContext.tsx
+++ b/src/context/ConfigContext.tsx
@@ -156,6 +156,9 @@ type ContextProps = {
   clearError: () => void;
   deprecationWarning: string | null;
   clearWarning: () => void;
+  info: string | null;
+  setInfo: Dispatch<SetStateAction<string | null>>;
+  clearInfo: () => void;
   results: Results | null;
   resultsVersion: number;
   setResultsVersion: Dispatch<SetStateAction<number>>;
@@ -549,6 +552,7 @@ const ConfigContextProvider = ({
   const [deprecationWarning, setDeprecationWarning] = useState<string | null>(
     null
   );
+  const [info, setInfo] = useState<string | null>(null);
   const [results, setResults] = useState<Results | null>(null);
   const [resultsVersion, setResultsVersion] = useState<number>(0);
   const [settings, setSettings] = useLocalStorage<AppSettings>(
@@ -686,6 +690,7 @@ const ConfigContextProvider = ({
 
   const clearError = useCallback(() => setError(null), []);
   const clearWarning = useCallback(() => setDeprecationWarning(null), []);
+  const clearInfo = useCallback(() => setInfo(null), []);
 
   /**
    * Handler for messages received from the Ergogen worker.
@@ -1584,6 +1589,9 @@ const ConfigContextProvider = ({
       clearError,
       deprecationWarning,
       clearWarning,
+      info,
+      setInfo,
+      clearInfo,
       results,
       resultsVersion,
       setResultsVersion,
@@ -1642,6 +1650,9 @@ const ConfigContextProvider = ({
       clearError,
       deprecationWarning,
       clearWarning,
+      info,
+      setInfo,
+      clearInfo,
       results,
       resultsVersion,
       setResultsVersion,

--- a/src/hooks/useConfigLoader.ts
+++ b/src/hooks/useConfigLoader.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { fetchConfigFromUrl } from '../utils/github';
+import { mapSeparateToInjectionsArray } from '../utils/ergogenBundleLoader';
 
 interface UseConfigLoaderProps {
   processInjectionsWithConflictResolution: (
@@ -46,27 +47,11 @@ export const useConfigLoader = ({
           }
 
           // Convert footprints, outlines, and templates to injection array format
-          const footprintInjections: string[][] = result.footprints.map(
-            (fp) => ['footprint', fp.name, fp.content]
+          const newInjections = mapSeparateToInjectionsArray(
+            result.footprints,
+            result.outlines,
+            result.templates
           );
-
-          const outlineInjections: string[][] = result.outlines.map((fp) => [
-            'outline',
-            fp.name,
-            fp.content,
-          ]);
-
-          const templateInjections: string[][] = result.templates.map((fp) => [
-            'template',
-            fp.name,
-            fp.content,
-          ]);
-
-          const newInjections = [
-            ...footprintInjections,
-            ...outlineInjections,
-            ...templateInjections,
-          ];
 
           // Process injections with conflict resolution
           await processInjectionsWithConflictResolution(

--- a/src/organisms/Banners.tsx
+++ b/src/organisms/Banners.tsx
@@ -86,10 +86,32 @@ const Banners = () => {
     return null;
   }
 
-  const { error, deprecationWarning, clearError, clearWarning } = configContext;
+  const {
+    error,
+    deprecationWarning,
+    info,
+    clearError,
+    clearWarning,
+    clearInfo,
+  } = configContext;
 
   return (
     <BannersContainer data-testid="banners-container">
+      {info && (
+        <Banner type="info" data-testid="info-banner">
+          <BannerContent>
+            <BannerIcon>info</BannerIcon>
+            <BannerText>{info}</BannerText>
+          </BannerContent>
+          <CloseButton
+            onClick={clearInfo}
+            aria-label="Close info message"
+            data-testid="close-info-banner"
+          >
+            &times;
+          </CloseButton>
+        </Banner>
+      )}
       {deprecationWarning && (
         <Banner type="warning" data-testid="warning-banner">
           <BannerContent>

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -8,12 +8,33 @@ import EmptyYAML from '../examples/empty_yaml';
 import { fetchConfigFromUrl, GitHubFootprint } from '../utils/github';
 import { ConflictResolutionStrategy } from '../utils/injections';
 import { loadLocalFile } from '../utils/localFiles';
+import { mapSeparateToInjectionsArray } from '../utils/ergogenBundleLoader';
 import Button from '../atoms/Button';
 import ConflictResolutionDialog from '../molecules/ConflictResolutionDialog';
 import { trackEvent } from '../utils/analytics';
 import { useInjectionConflictResolution } from '../hooks/useInjectionConflictResolution';
 
-// Styled Components
+const Spinner = styled.div`
+  border: 3px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  border-top: 3px solid ${theme.colors.accent};
+  width: 1.2rem;
+  height: 1.2rem;
+  animation: spin 1s linear infinite;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 0.5rem;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+`;
+
 const WelcomePageWrapper = styled.div<{ $isDragging?: boolean }>`
   background-color: ${theme.colors.background};
   color: ${theme.colors.white};
@@ -361,11 +382,11 @@ const Welcome = () => {
     }
 
     // Convert footprints, outlines, and templates to injection array format
-    const injections: string[][] = [
-      ...footprints.map((fp) => ['footprint', fp.name, fp.content]),
-      ...outlines.map((ot) => ['outline', ot.name, ot.content]),
-      ...templates.map((tmpl) => ['template', tmpl.name, tmpl.content]),
-    ];
+    const injections = mapSeparateToInjectionsArray(
+      footprints,
+      outlines,
+      templates
+    );
 
     // Use the hook's process function
     await processInjectionsWithConflictResolution(
@@ -422,6 +443,19 @@ const Welcome = () => {
 
           try {
             configContext.createNewConfig(result.config);
+
+            const footprintCount = result.footprints.length;
+            const outlineCount = result.outlines.length;
+            const templateCount = result.templates.length;
+
+            if (footprintCount || outlineCount || templateCount) {
+              configContext.setInfo(
+                `Config loaded successfully from GitHub. Found ${footprintCount} footprints, ${outlineCount} outlines, and ${templateCount} templates.`
+              );
+            } else {
+              configContext.setInfo('Config loaded successfully from GitHub.');
+            }
+
             // Process footprints with conflict resolution
             await processInjections(
               result.footprints,
@@ -439,6 +473,7 @@ const Welcome = () => {
       })
       .catch((e) => {
         setError(`Failed to load from GitHub: ${e.message}`);
+        configContext?.setInfo(null);
         // Ensure we reset loading state and don't navigate
         setIsLoading(false);
         setIsGenerating(false);
@@ -478,6 +513,19 @@ const Welcome = () => {
       const result = await loadLocalFile(file);
 
       configContext.createNewConfig(result.config);
+
+      const footprintCount = result.footprints.length;
+      const outlineCount = result.outlines.length;
+      const templateCount = result.templates.length;
+
+      if (footprintCount || outlineCount || templateCount) {
+        configContext.setInfo(
+          `Config loaded successfully. Found ${footprintCount} footprints, ${outlineCount} outlines, and ${templateCount} templates.`
+        );
+      } else {
+        configContext.setInfo('Config loaded successfully.');
+      }
+
       // Process footprints with conflict resolution
       await processInjections(
         result.footprints,
@@ -489,6 +537,7 @@ const Welcome = () => {
       setError(
         `Failed to load local file: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
+      configContext.setInfo(null);
       // Ensure we reset loading state and don't navigate
       setIsLoading(false);
       setIsGenerating(false);
@@ -514,6 +563,7 @@ const Welcome = () => {
   const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    if (isLoading) return;
     setIsDragging(true);
   };
 
@@ -525,6 +575,7 @@ const Welcome = () => {
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    if (isLoading) return;
     // Check if we're actually leaving the wrapper element
     const currentTarget = e.currentTarget as HTMLElement;
     const relatedTarget = e.relatedTarget as HTMLElement | null;
@@ -538,6 +589,7 @@ const Welcome = () => {
   const handleDrop = async (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    if (isLoading) return;
     setIsDragging(false);
 
     const files = Array.from(e.dataTransfer.files);
@@ -623,7 +675,13 @@ const Welcome = () => {
               aria-label="Select local file to load"
               data-testid="local-file-button"
             >
-              {isLoading ? 'Loading...' : 'Choose File'}
+              {isLoading ? (
+                <>
+                  <Spinner /> Loading...
+                </>
+              ) : (
+                'Choose File'
+              )}
             </Button>
           </OptionBox>
           <OptionBox>
@@ -657,7 +715,13 @@ const Welcome = () => {
                 aria-label="Load configuration from GitHub"
                 data-testid="github-load-button"
               >
-                {isLoading ? 'Loading...' : 'Load'}
+                {isLoading ? (
+                  <>
+                    <Spinner /> Loading...
+                  </>
+                ) : (
+                  'Load'
+                )}
               </Button>
             </GitHubInputContainer>
           </OptionBox>

--- a/src/utils/ergogenBundleLoader.test.ts
+++ b/src/utils/ergogenBundleLoader.test.ts
@@ -1,0 +1,194 @@
+import JSZip from 'jszip';
+import {
+  cleanInjectionName,
+  validateZipStructure,
+  enforceFileSizeLimit,
+  mapToInjectionsArray,
+  mapSeparateToInjectionsArray,
+  parseZipArchive,
+  MAX_ARCHIVE_SIZE_BYTES,
+  MAX_TEXT_FILE_SIZE_BYTES,
+  ErgogenInjection,
+  ErgogenWorkspaceBundle,
+} from './ergogenBundleLoader';
+import { isFeatureEnabled } from './featureFlags';
+
+// Mock featureFlags
+jest.mock('./featureFlags', () => ({
+  isFeatureEnabled: jest.fn(),
+}));
+
+describe('ergogenBundleLoader', () => {
+  beforeEach(() => {
+    (isFeatureEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  describe('cleanInjectionName', () => {
+    it('should extract footprint name removing footprints/ prefix and .js extension', () => {
+      expect(
+        cleanInjectionName('footprints/ceoloide/key.js', 'footprints')
+      ).toBe('ceoloide/key');
+    });
+
+    it('should extract outline name removing outlines/ prefix and .js extension', () => {
+      expect(cleanInjectionName('outlines/my_outline.js', 'outlines')).toBe(
+        'my_outline'
+      );
+    });
+
+    it('should extract template name removing templates/ prefix and .js extension', () => {
+      expect(cleanInjectionName('templates/custom/case.js', 'templates')).toBe(
+        'custom/case'
+      );
+    });
+  });
+
+  describe('validateZipStructure', () => {
+    it('should return config.yaml file if present in JSZip', () => {
+      const zip = new JSZip();
+      zip.file('config.yaml', 'points: {}');
+      const file = validateZipStructure(zip);
+      expect(file).toBeDefined();
+      expect(file?.name).toBe('config.yaml');
+    });
+
+    it('should return config.yml file if config.yaml is absent', () => {
+      const zip = new JSZip();
+      zip.file('config.yml', 'points: {}');
+      const file = validateZipStructure(zip);
+      expect(file).toBeDefined();
+      expect(file?.name).toBe('config.yml');
+    });
+
+    it('should perform case-insensitive checks', () => {
+      const zip = new JSZip();
+      zip.file('CONFIG.YAML', 'points: {}');
+      const file = validateZipStructure(zip);
+      expect(file).toBeDefined();
+      expect(file?.name).toBe('CONFIG.YAML');
+    });
+
+    it('should throw an error if no config.yaml or config.yml is found', () => {
+      const zip = new JSZip();
+      zip.file('footprints/ceoloide/key.js', 'console.log()');
+      expect(() => validateZipStructure(zip)).toThrow(
+        'The archive is missing a config.yaml file in the root directory.'
+      );
+    });
+  });
+
+  describe('enforceFileSizeLimit', () => {
+    it('should not throw error if file sizes are within limits', () => {
+      expect(() =>
+        enforceFileSizeLimit(MAX_ARCHIVE_SIZE_BYTES - 100, true)
+      ).not.toThrow();
+      expect(() =>
+        enforceFileSizeLimit(MAX_TEXT_FILE_SIZE_BYTES - 100, false)
+      ).not.toThrow();
+    });
+
+    it('should throw error if zip file size exceeds limit', () => {
+      expect(() =>
+        enforceFileSizeLimit(MAX_ARCHIVE_SIZE_BYTES + 1, true)
+      ).toThrow(/exceeds the maximum size limit of 50MB/);
+    });
+
+    it('should throw error if text file size exceeds limit', () => {
+      expect(() =>
+        enforceFileSizeLimit(MAX_TEXT_FILE_SIZE_BYTES + 1, false)
+      ).toThrow(/exceeds the maximum size limit of 10MB/);
+    });
+  });
+
+  describe('mapToInjectionsArray', () => {
+    it('should map injections list to string[][] format', () => {
+      const input = [
+        { type: 'footprint' as const, name: 'key', content: 'foo' },
+        { type: 'outline' as const, name: 'my_outline', content: 'bar' },
+      ];
+      expect(mapToInjectionsArray(input)).toEqual([
+        ['footprint', 'key', 'foo'],
+        ['outline', 'my_outline', 'bar'],
+      ]);
+    });
+  });
+
+  describe('mapSeparateToInjectionsArray', () => {
+    it('should map separate footprints, outlines, and templates to string[][] format', () => {
+      const footprints = [{ name: 'f1', content: 'c1' }];
+      const outlines = [{ name: 'o1', content: 'c2' }];
+      const templates = [{ name: 't1', content: 'c3' }];
+      expect(
+        mapSeparateToInjectionsArray(footprints, outlines, templates)
+      ).toEqual([
+        ['footprint', 'f1', 'c1'],
+        ['outline', 'o1', 'c2'],
+        ['template', 't1', 'c3'],
+      ]);
+    });
+  });
+
+  describe('parseZipArchive', () => {
+    it('should parse valid zip buffer and extract configs and custom footprint injections', async () => {
+      const zip = new JSZip();
+      zip.file('config.yaml', 'points: {}');
+      zip.file('footprints/ceoloide/key.js', 'console.log("fp")');
+      zip.file('outlines/my_outline.js', 'console.log("outline")');
+      zip.file('templates/my_template.js', 'console.log("template")');
+
+      const arrayBuffer = await zip.generateAsync({ type: 'arraybuffer' });
+      const result = await parseZipArchive(arrayBuffer);
+
+      expect(result.config).toBe('points: {}');
+      expect(result.injections).toEqual([
+        {
+          type: 'footprint',
+          name: 'ceoloide/key',
+          content: 'console.log("fp")',
+        },
+        {
+          type: 'outline',
+          name: 'my_outline',
+          content: 'console.log("outline")',
+        },
+        {
+          type: 'template',
+          name: 'my_template',
+          content: 'console.log("template")',
+        },
+      ]);
+    });
+
+    it('should ignore outlines and templates if feature flags are disabled', async () => {
+      (isFeatureEnabled as jest.Mock).mockImplementation((feature) => {
+        if (feature === 'outlines' || feature === 'templates') return false;
+        return true;
+      });
+
+      const zip = new JSZip();
+      zip.file('config.yaml', 'points: {}');
+      zip.file('footprints/ceoloide/key.js', 'console.log("fp")');
+      zip.file('outlines/my_outline.js', 'console.log("outline")');
+      zip.file('templates/my_template.js', 'console.log("template")');
+
+      const arrayBuffer = await zip.generateAsync({ type: 'arraybuffer' });
+      const result = await parseZipArchive(arrayBuffer);
+
+      expect(result.config).toBe('points: {}');
+      expect(result.injections).toEqual([
+        {
+          type: 'footprint',
+          name: 'ceoloide/key',
+          content: 'console.log("fp")',
+        },
+      ]);
+    });
+
+    it('should throw friendly error if arraybuffer is corrupted or invalid zip', async () => {
+      const arrayBuffer = new ArrayBuffer(10);
+      await expect(parseZipArchive(arrayBuffer)).rejects.toThrow(
+        'The file appears to be corrupted. Please verify the file and try again.'
+      );
+    });
+  });
+});

--- a/src/utils/ergogenBundleLoader.ts
+++ b/src/utils/ergogenBundleLoader.ts
@@ -1,0 +1,155 @@
+import JSZip from 'jszip';
+import { isFeatureEnabled } from './featureFlags';
+
+export interface ErgogenInjection {
+  type: 'footprint' | 'outline' | 'template';
+  name: string;
+  content: string;
+}
+
+export interface ErgogenWorkspaceBundle {
+  config: string;
+  injections: ErgogenInjection[];
+  configPath?: string;
+  rateLimitWarning?: string;
+}
+
+// Configurable constants
+export const MAX_ARCHIVE_SIZE_BYTES = 50 * 1024 * 1024; // 50MB
+export const MAX_TEXT_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
+/**
+ * Extracts injection name from relative file path.
+ * e.g., footprints/ceoloide/key.js -> ceoloide/key
+ */
+export const cleanInjectionName = (
+  path: string,
+  type: 'footprints' | 'outlines' | 'templates'
+): string => {
+  const prefix = `${type}/`;
+  let name = path;
+  if (name.startsWith(prefix)) {
+    name = name.substring(prefix.length);
+  }
+  name = name.replace(/\.js$/, '');
+  return name;
+};
+
+/**
+ * Validates zip structural contents and retrieves config file object.
+ */
+export const validateZipStructure = (zip: JSZip): JSZip.JSZipObject => {
+  let configFile = zip.file('config.yaml') || zip.file('config.yml');
+  if (!configFile) {
+    // Try case-insensitive lookup
+    const matches = zip.file(/^config\.(yaml|yml)$/i);
+    if (matches && matches.length > 0) {
+      configFile = matches[0];
+    }
+  }
+  if (!configFile) {
+    throw new Error(
+      'The archive is missing a config.yaml file in the root directory.'
+    );
+  }
+  return configFile;
+};
+
+/**
+ * Enforces file size constraints.
+ */
+export const enforceFileSizeLimit = (
+  fileSize: number,
+  isArchive: boolean
+): void => {
+  if (isArchive && fileSize > MAX_ARCHIVE_SIZE_BYTES) {
+    throw new Error(
+      `File exceeds the maximum size limit of 50MB for archives (current size: ${(fileSize / (1024 * 1024)).toFixed(1)}MB).`
+    );
+  }
+  if (!isArchive && fileSize > MAX_TEXT_FILE_SIZE_BYTES) {
+    throw new Error(
+      `File exceeds the maximum size limit of 10MB for text files (current size: ${(fileSize / (1024 * 1024)).toFixed(1)}MB).`
+    );
+  }
+};
+
+export const mapToInjectionsArray = (
+  injections: ErgogenInjection[]
+): string[][] => {
+  return injections.map((inj) => [inj.type, inj.name, inj.content]);
+};
+
+/**
+ * Transforms separated footprint/outline/template array lists into the raw context injections format string[][].
+ */
+export const mapSeparateToInjectionsArray = (
+  footprints: { name: string; content: string }[],
+  outlines: { name: string; content: string }[],
+  templates: { name: string; content: string }[]
+): string[][] => {
+  const injections: string[][] = [];
+  footprints.forEach((f) => injections.push(['footprint', f.name, f.content]));
+  outlines.forEach((o) => injections.push(['outline', o.name, o.content]));
+  templates.forEach((t) => injections.push(['template', t.name, t.content]));
+  return injections;
+};
+
+/**
+ * Unpacks and parses a JSZip archive into an ErgogenWorkspaceBundle.
+ */
+export const parseZipArchive = async (
+  arrayBuffer: ArrayBuffer
+): Promise<ErgogenWorkspaceBundle> => {
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(arrayBuffer);
+  } catch (_err) {
+    throw new Error(
+      'The file appears to be corrupted. Please verify the file and try again.'
+    );
+  }
+
+  const configFile = validateZipStructure(zip);
+  const config = await configFile.async('string');
+
+  const injections: ErgogenInjection[] = [];
+  const promises: Promise<void>[] = [];
+
+  zip.forEach((relativePath, file) => {
+    if (file.dir || !relativePath.endsWith('.js')) return;
+
+    if (relativePath.startsWith('footprints/')) {
+      const promise = file.async('string').then((content) => {
+        const name = cleanInjectionName(relativePath, 'footprints');
+        injections.push({ type: 'footprint', name, content });
+      });
+      promises.push(promise);
+    } else if (
+      relativePath.startsWith('outlines/') &&
+      isFeatureEnabled('outlines')
+    ) {
+      const promise = file.async('string').then((content) => {
+        const name = cleanInjectionName(relativePath, 'outlines');
+        injections.push({ type: 'outline', name, content });
+      });
+      promises.push(promise);
+    } else if (
+      relativePath.startsWith('templates/') &&
+      isFeatureEnabled('templates')
+    ) {
+      const promise = file.async('string').then((content) => {
+        const name = cleanInjectionName(relativePath, 'templates');
+        injections.push({ type: 'template', name, content });
+      });
+      promises.push(promise);
+    }
+  });
+
+  await Promise.all(promises);
+
+  return {
+    config,
+    injections,
+  };
+};

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -1,4 +1,5 @@
 import { isFeatureEnabled } from './featureFlags';
+import { enforceFileSizeLimit } from './ergogenBundleLoader';
 
 /**
  * Converts a standard GitHub file URL to its corresponding raw content URL.
@@ -24,6 +25,10 @@ export const checkRateLimit = (
   response: Response,
   url: string
 ): { isLimitExceeded: boolean; error: string | null } => {
+  if (!response) {
+    return { isLimitExceeded: false, error: null };
+  }
+
   // Check if this is a raw content URL (raw.githubusercontent.com)
   const isRawContent = url.includes('raw.githubusercontent.com');
 
@@ -44,10 +49,10 @@ export const checkRateLimit = (
   }
 
   // For api.github.com requests, check rate limit headers
-  const limit = response.headers.get('X-RateLimit-Limit') || 'unknown';
-  const remaining = response.headers.get('X-RateLimit-Remaining') || 'unknown';
-  const used = response.headers.get('X-RateLimit-Used') || 'unknown';
-  const reset = response.headers.get('X-RateLimit-Reset') || 'unknown';
+  const limit = response.headers?.get('X-RateLimit-Limit') || 'unknown';
+  const remaining = response.headers?.get('X-RateLimit-Remaining') || 'unknown';
+  const used = response.headers?.get('X-RateLimit-Used') || 'unknown';
+  const reset = response.headers?.get('X-RateLimit-Reset') || 'unknown';
 
   // Log rate limit info
   console.log(
@@ -443,6 +448,7 @@ export const fetchConfigFromUrl = async (
       throw new Error(`HTTP error! status: ${response.status}`);
     }
     const config = await response.text();
+    enforceFileSizeLimit(config.length, false);
 
     // Check if the file is named config.yaml to decide if we should look for footprints
     const filename = baseUrl.split('/').pop() || '';
@@ -1002,9 +1008,8 @@ export const fetchConfigFromUrl = async (
       console.warn('[GitHub] No .gitmodules found or failed to parse:', error);
     }
 
-    console.log(`[GitHub] Total footprints loaded: ${footprints.length}`);
-    console.log(`[GitHub] Total outlines loaded: ${outlines.length}`);
-    console.log(`[GitHub] Total templates loaded: ${templates.length}`);
+    enforceFileSizeLimit(config.length, false);
+
     return {
       config,
       footprints,

--- a/src/utils/localFiles.test.ts
+++ b/src/utils/localFiles.test.ts
@@ -1,4 +1,4 @@
-import { loadLocalFile } from './localFiles';
+import { loadLocalFile, LocalFileLoadResult } from './localFiles';
 import JSZip from 'jszip';
 import { isFeatureEnabled } from './featureFlags';
 

--- a/src/utils/localFiles.ts
+++ b/src/utils/localFiles.ts
@@ -1,15 +1,13 @@
-import JSZip from 'jszip';
-import { GitHubFootprint } from './github';
-import { isFeatureEnabled } from './featureFlags';
+import { parseZipArchive, enforceFileSizeLimit } from './ergogenBundleLoader';
 
 /**
  * Result of loading a local file.
  */
-type LocalFileLoadResult = {
+export type LocalFileLoadResult = {
   config: string;
-  footprints: GitHubFootprint[];
-  outlines: GitHubFootprint[];
-  templates: GitHubFootprint[];
+  footprints: { name: string; content: string }[];
+  outlines: { name: string; content: string }[];
+  templates: { name: string; content: string }[];
 };
 
 /**
@@ -33,111 +31,9 @@ const loadTextFile = async (file: File): Promise<string> => {
 };
 
 /**
- * Extracts footprint name from a file path within the footprints folder.
- * Removes the 'footprints/' prefix and the '.js' extension.
- * @param path - The full path within the zip (e.g., 'footprints/ceoloide/utility_text.js').
- * @returns The footprint name (e.g., 'ceoloide/utility_text').
- */
-/**
- * Extracts outline name from a file path within the outlines folder.
- * Removes the 'outlines/' prefix and the '.js' extension.
- * @param path - The full path within the zip (e.g., 'outlines/my_outline.js').
- * @returns The outline name (e.g., 'my_outline').
- */
-const extractOutlineName = (path: string): string => {
-  // Remove 'outlines/' prefix
-  let name = path.replace(/^outlines\//, '');
-  // Remove '.js' extension
-  name = name.replace(/\.js$/, '');
-  return name;
-};
-
-const extractFootprintName = (path: string): string => {
-  // Remove 'footprints/' prefix
-  let name = path.replace(/^footprints\//, '');
-  // Remove '.js' extension
-  name = name.replace(/\.js$/, '');
-  return name;
-};
-
-const extractTemplateName = (path: string): string => {
-  // Remove 'templates/' prefix
-  let name = path.replace(/^templates\//, '');
-  // Remove '.js' extension
-  name = name.replace(/\.js$/, '');
-  return name;
-};
-
-/**
- * Loads a zip or ekb archive and extracts config.yaml and footprints.
- * @param file - The zip/ekb file to load.
- * @returns A promise that resolves with the config and footprints.
- * @throws Error if config.yaml is missing from the archive.
- */
-const loadZipArchive = async (file: File): Promise<LocalFileLoadResult> => {
-  const arrayBuffer = await file.arrayBuffer();
-  const zip = await JSZip.loadAsync(arrayBuffer);
-
-  // Find config.yaml in the root (check both config.yaml and config.yml)
-  let configFile = zip.file('config.yaml') || zip.file('config.yml');
-  if (!configFile) {
-    // Try case-insensitive search
-    configFile = zip.file(/^config\.(yaml|yml)$/i)[0];
-  }
-  if (!configFile) {
-    throw new Error(
-      'The archive is missing a config.yaml file in the root directory.'
-    );
-  }
-
-  const config = await configFile.async('string');
-
-  // Extract footprints, outlines and templates
-  const footprints: GitHubFootprint[] = [];
-  const outlines: GitHubFootprint[] = [];
-  const templates: GitHubFootprint[] = [];
-  const promises: Promise<void>[] = [];
-
-  zip.forEach((relativePath, file) => {
-    if (file.dir || !relativePath.endsWith('.js')) return;
-
-    if (relativePath.startsWith('footprints/')) {
-      const promise = file.async('string').then((content) => {
-        const name = extractFootprintName(relativePath);
-        footprints.push({ name, content });
-      });
-      promises.push(promise);
-    } else if (
-      relativePath.startsWith('outlines/') &&
-      isFeatureEnabled('outlines')
-    ) {
-      const promise = file.async('string').then((content) => {
-        const name = extractOutlineName(relativePath);
-        outlines.push({ name, content });
-      });
-      promises.push(promise);
-    } else if (
-      relativePath.startsWith('templates/') &&
-      isFeatureEnabled('templates')
-    ) {
-      const promise = file.async('string').then((content) => {
-        const name = extractTemplateName(relativePath);
-        templates.push({ name, content });
-      });
-      promises.push(promise);
-    }
-  });
-
-  // Wait for all files to be read
-  await Promise.all(promises);
-
-  return { config, footprints, outlines, templates };
-};
-
-/**
- * Loads a local file (yaml, json, zip, or ekb) and extracts config and footprints.
+ * Loads a local file (yaml, json, zip, or ekb) and extracts config and footprints/outlines/templates.
  * @param file - The file to load.
- * @returns A promise that resolves with the config and footprints.
+ * @returns A promise that resolves with the config and injections.
  * @throws Error if the file type is not supported or if required files are missing.
  */
 export const loadLocalFile = async (
@@ -145,14 +41,33 @@ export const loadLocalFile = async (
 ): Promise<LocalFileLoadResult> => {
   const fileName = file.name.toLowerCase();
   const extension = fileName.split('.').pop();
+  const isArchive = extension === 'zip' || extension === 'ekb';
+
+  // Enforce size limits
+  enforceFileSizeLimit(file.size, isArchive);
 
   if (extension === 'yaml' || extension === 'yml' || extension === 'json') {
     // Load as text file
     const config = await loadTextFile(file);
     return { config, footprints: [], outlines: [], templates: [] };
-  } else if (extension === 'zip' || extension === 'ekb') {
+  } else if (isArchive) {
     // Load as zip archive
-    return await loadZipArchive(file);
+    const arrayBuffer = await file.arrayBuffer();
+    const result = await parseZipArchive(arrayBuffer);
+
+    const footprints = result.injections
+      .filter((i) => i.type === 'footprint')
+      .map((i) => ({ name: i.name, content: i.content }));
+
+    const outlines = result.injections
+      .filter((i) => i.type === 'outline')
+      .map((i) => ({ name: i.name, content: i.content }));
+
+    const templates = result.injections
+      .filter((i) => i.type === 'template')
+      .map((i) => ({ name: i.name, content: i.content }));
+
+    return { config: result.config, footprints, outlines, templates };
   } else {
     throw new Error(
       `Unsupported file type. Accepted formats: *.yaml, *.json, *.zip, *.ekb`

--- a/src/utils/zip.test.ts
+++ b/src/utils/zip.test.ts
@@ -63,7 +63,10 @@ describe('createZip', () => {
     await createZip(results as any, config, undefined, false, false);
 
     expect(mockZip.file).toHaveBeenCalledWith('config.yaml', config);
-    expect(mockZip.file).toHaveBeenCalledWith('demo.svg', '<svg>demo</svg>');
+    expect(mockFolders['outputs'].file).toHaveBeenCalledWith(
+      'demo.svg',
+      '<svg>demo</svg>'
+    );
   });
 
   it('should include outlines and filter "_" prefixed files when debug is false', async () => {
@@ -77,7 +80,8 @@ describe('createZip', () => {
     await createZip(results as any, '', undefined, false, false);
 
     const outlinesFolder = mockFolders['outlines'];
-    expect(mockZip.folder).toHaveBeenCalledWith('outlines');
+    expect(mockZip.folder).toHaveBeenCalledWith('outputs');
+    expect(mockFolders['outputs'].folder).toHaveBeenCalledWith('outlines');
     expect(outlinesFolder.file).toHaveBeenCalledWith(
       'visible.dxf',
       'visible-dxf'
@@ -103,6 +107,8 @@ describe('createZip', () => {
     await createZip(results as any, '', undefined, true, false);
 
     const outlinesFolder = mockFolders['outlines'];
+    expect(mockZip.folder).toHaveBeenCalledWith('outputs');
+    expect(mockFolders['outputs'].folder).toHaveBeenCalledWith('outlines');
     expect(outlinesFolder.file).toHaveBeenCalledWith(
       'visible.dxf',
       'visible-dxf'
@@ -124,7 +130,8 @@ describe('createZip', () => {
     await createZip(results as any, '', undefined, false, false);
 
     const pcbsFolder = mockFolders['pcbs'];
-    expect(mockZip.folder).toHaveBeenCalledWith('pcbs');
+    expect(mockZip.folder).toHaveBeenCalledWith('outputs');
+    expect(mockFolders['outputs'].folder).toHaveBeenCalledWith('pcbs');
     expect(pcbsFolder.file).toHaveBeenCalledWith(
       'main.kicad_pcb',
       'pcb-content'
@@ -145,6 +152,8 @@ describe('createZip', () => {
     // stlPreview = false
     await createZip(results as any, '', undefined, false, false);
     let casesFolder = mockFolders['cases'];
+    expect(mockZip.folder).toHaveBeenCalledWith('outputs');
+    expect(mockFolders['outputs'].folder).toHaveBeenCalledWith('cases');
     expect(casesFolder.file).toHaveBeenCalledWith(
       'case1.jscad',
       'jscad-content'
@@ -161,6 +170,8 @@ describe('createZip', () => {
     // stlPreview = true
     await createZip(results as any, '', undefined, false, true);
     casesFolder = mockFolders['cases'];
+    expect(mockZip.folder).toHaveBeenCalledWith('outputs');
+    expect(mockFolders['outputs'].folder).toHaveBeenCalledWith('cases');
     expect(casesFolder.file).toHaveBeenCalledWith(
       'case1.jscad',
       'jscad-content'
@@ -180,7 +191,8 @@ describe('createZip', () => {
     await createZip(results as any, config, undefined, true, false);
 
     const debugFolder = mockFolders['debug'];
-    expect(mockZip.folder).toHaveBeenCalledWith('debug');
+    expect(mockZip.folder).toHaveBeenCalledWith('outputs');
+    expect(mockFolders['outputs'].folder).toHaveBeenCalledWith('debug');
     expect(debugFolder.file).toHaveBeenCalledWith('raw.txt', config);
     expect(debugFolder.file).toHaveBeenCalledWith(
       'canonical.yaml',

--- a/src/utils/zip.ts
+++ b/src/utils/zip.ts
@@ -78,76 +78,82 @@ export const createZip = async (
   const zip = new JSZip();
 
   // Root folder
-  if (results.demo?.svg) {
-    zip.file('demo.svg', results.demo.svg);
-  }
   zip.file('config.yaml', config);
 
-  // Outlines folder
-  if (results.outlines) {
-    let outlinesFolder: JSZip | null = null;
-    for (const [name, outline] of Object.entries(results.outlines)) {
-      if (debug || !name.startsWith('_')) {
-        if (outline.dxf || outline.svg) {
-          if (!outlinesFolder) {
-            outlinesFolder = zip.folder('outlines');
-          }
-          if (outlinesFolder) {
-            if (outline.dxf) {
-              outlinesFolder.file(`${name}.dxf`, outline.dxf);
+  // Create outputs folder
+  const outputsFolder = zip.folder('outputs');
+
+  if (outputsFolder) {
+    if (results.demo?.svg) {
+      outputsFolder.file('demo.svg', results.demo.svg);
+    }
+
+    // Outlines folder
+    if (results.outlines) {
+      let outlinesFolder: JSZip | null = null;
+      for (const [name, outline] of Object.entries(results.outlines)) {
+        if (debug || !name.startsWith('_')) {
+          if (outline.dxf || outline.svg) {
+            if (!outlinesFolder) {
+              outlinesFolder = outputsFolder.folder('outlines');
             }
-            if (outline.svg) {
-              outlinesFolder.file(`${name}.svg`, outline.svg);
+            if (outlinesFolder) {
+              if (outline.dxf) {
+                outlinesFolder.file(`${name}.dxf`, outline.dxf);
+              }
+              if (outline.svg) {
+                outlinesFolder.file(`${name}.svg`, outline.svg);
+              }
             }
           }
         }
       }
     }
-  }
 
-  // PCBs folder
-  if (results.pcbs && Object.keys(results.pcbs).length > 0) {
-    const pcbsFolder = zip.folder('pcbs');
-    if (pcbsFolder) {
-      for (const [name, pcb] of Object.entries(results.pcbs)) {
-        const fileName = name.endsWith('.kicad_pcb')
-          ? name
-          : `${name}.kicad_pcb`;
-        pcbsFolder.file(fileName, pcb);
-      }
-    }
-  }
-
-  // Cases folder
-  if (results.cases) {
-    let casesFolder: JSZip | null = null;
-    for (const [name, caseData] of Object.entries(results.cases)) {
-      const hasJscad = !!caseData.jscad;
-      const hasStl = stlPreview && !!caseData.stl;
-      if (hasJscad || hasStl) {
-        if (!casesFolder) {
-          casesFolder = zip.folder('cases');
-        }
-        if (casesFolder) {
-          if (caseData.jscad) {
-            casesFolder.file(`${name}.jscad`, caseData.jscad);
-          }
-          if (stlPreview && caseData.stl) {
-            casesFolder.file(`${name}.stl`, caseData.stl);
-          }
+    // PCBs folder
+    if (results.pcbs && Object.keys(results.pcbs).length > 0) {
+      const pcbsFolder = outputsFolder.folder('pcbs');
+      if (pcbsFolder) {
+        for (const [name, pcb] of Object.entries(results.pcbs)) {
+          const fileName = name.endsWith('.kicad_pcb')
+            ? name
+            : `${name}.kicad_pcb`;
+          pcbsFolder.file(fileName, pcb);
         }
       }
     }
-  }
 
-  // Debug folder
-  if (debug) {
-    const debugFolder = zip.folder('debug');
-    if (debugFolder) {
-      debugFolder.file('raw.txt', config);
-      for (const [key, value] of Object.entries(results)) {
-        if (['canonical', 'points', 'units'].includes(key)) {
-          debugFolder.file(`${key}.yaml`, JSON.stringify(value, null, 2));
+    // Cases folder
+    if (results.cases) {
+      let casesFolder: JSZip | null = null;
+      for (const [name, caseData] of Object.entries(results.cases)) {
+        const hasJscad = !!caseData.jscad;
+        const hasStl = stlPreview && !!caseData.stl;
+        if (hasJscad || hasStl) {
+          if (!casesFolder) {
+            casesFolder = outputsFolder.folder('cases');
+          }
+          if (casesFolder) {
+            if (caseData.jscad) {
+              casesFolder.file(`${name}.jscad`, caseData.jscad);
+            }
+            if (stlPreview && caseData.stl) {
+              casesFolder.file(`${name}.stl`, caseData.stl);
+            }
+          }
+        }
+      }
+    }
+
+    // Debug folder
+    if (debug) {
+      const debugFolder = outputsFolder.folder('debug');
+      if (debugFolder) {
+        debugFolder.file('raw.txt', config);
+        for (const [key, value] of Object.entries(results)) {
+          if (['canonical', 'points', 'units'].includes(key)) {
+            debugFolder.file(`${key}.yaml`, JSON.stringify(value, null, 2));
+          }
         }
       }
     }
@@ -294,68 +300,73 @@ export const exportAllConfigs = async (
         finalResults = await compileJscadToStl(results);
       }
 
-      if (finalResults.demo?.svg) {
-        configFolder.file('demo.svg', finalResults.demo.svg);
-      }
       configFolder.file('config.yaml', configRecord.config);
 
-      if (finalResults.outlines) {
-        let outlinesFolder: JSZip | null = null;
-        for (const [name, outline] of Object.entries(finalResults.outlines)) {
-          if (debug || !name.startsWith('_')) {
-            if (outline.dxf || outline.svg) {
-              if (!outlinesFolder) {
-                outlinesFolder = configFolder.folder('outlines');
+      const outputsFolder = configFolder.folder('outputs');
+
+      if (outputsFolder) {
+        if (finalResults.demo?.svg) {
+          outputsFolder.file('demo.svg', finalResults.demo.svg);
+        }
+
+        if (finalResults.outlines) {
+          let outlinesFolder: JSZip | null = null;
+          for (const [name, outline] of Object.entries(finalResults.outlines)) {
+            if (debug || !name.startsWith('_')) {
+              if (outline.dxf || outline.svg) {
+                if (!outlinesFolder) {
+                  outlinesFolder = outputsFolder.folder('outlines');
+                }
+                if (outlinesFolder) {
+                  if (outline.dxf)
+                    outlinesFolder.file(`${name}.dxf`, outline.dxf);
+                  if (outline.svg)
+                    outlinesFolder.file(`${name}.svg`, outline.svg);
+                }
               }
-              if (outlinesFolder) {
-                if (outline.dxf)
-                  outlinesFolder.file(`${name}.dxf`, outline.dxf);
-                if (outline.svg)
-                  outlinesFolder.file(`${name}.svg`, outline.svg);
+            }
+          }
+        }
+
+        if (finalResults.pcbs && Object.keys(finalResults.pcbs).length > 0) {
+          const pcbsFolder = outputsFolder.folder('pcbs');
+          if (pcbsFolder) {
+            for (const [name, pcb] of Object.entries(finalResults.pcbs)) {
+              const fileName = name.endsWith('.kicad_pcb')
+                ? name
+                : `${name}.kicad_pcb`;
+              pcbsFolder.file(fileName, pcb);
+            }
+          }
+        }
+
+        if (finalResults.cases) {
+          let casesFolder: JSZip | null = null;
+          for (const [name, caseData] of Object.entries(finalResults.cases)) {
+            const hasJscad = !!caseData.jscad;
+            const hasStl = stlPreview && !!caseData.stl;
+            if (hasJscad || hasStl) {
+              if (!casesFolder) {
+                casesFolder = outputsFolder.folder('cases');
+              }
+              if (casesFolder) {
+                if (caseData.jscad)
+                  casesFolder.file(`${name}.jscad`, caseData.jscad);
+                if (stlPreview && caseData.stl)
+                  casesFolder.file(`${name}.stl`, caseData.stl);
               }
             }
           }
         }
-      }
 
-      if (finalResults.pcbs && Object.keys(finalResults.pcbs).length > 0) {
-        const pcbsFolder = configFolder.folder('pcbs');
-        if (pcbsFolder) {
-          for (const [name, pcb] of Object.entries(finalResults.pcbs)) {
-            const fileName = name.endsWith('.kicad_pcb')
-              ? name
-              : `${name}.kicad_pcb`;
-            pcbsFolder.file(fileName, pcb);
-          }
-        }
-      }
-
-      if (finalResults.cases) {
-        let casesFolder: JSZip | null = null;
-        for (const [name, caseData] of Object.entries(finalResults.cases)) {
-          const hasJscad = !!caseData.jscad;
-          const hasStl = stlPreview && !!caseData.stl;
-          if (hasJscad || hasStl) {
-            if (!casesFolder) {
-              casesFolder = configFolder.folder('cases');
-            }
-            if (casesFolder) {
-              if (caseData.jscad)
-                casesFolder.file(`${name}.jscad`, caseData.jscad);
-              if (stlPreview && caseData.stl)
-                casesFolder.file(`${name}.stl`, caseData.stl);
-            }
-          }
-        }
-      }
-
-      if (debug) {
-        const debugFolder = configFolder.folder('debug');
-        if (debugFolder) {
-          debugFolder.file('raw.txt', configRecord.config);
-          for (const [key, value] of Object.entries(finalResults)) {
-            if (['canonical', 'points', 'units'].includes(key)) {
-              debugFolder.file(`${key}.yaml`, JSON.stringify(value, null, 2));
+        if (debug) {
+          const debugFolder = outputsFolder.folder('debug');
+          if (debugFolder) {
+            debugFolder.file('raw.txt', configRecord.config);
+            for (const [key, value] of Object.entries(finalResults)) {
+              if (['canonical', 'points', 'units'].includes(key)) {
+                debugFolder.file(`${key}.yaml`, JSON.stringify(value, null, 2));
+              }
             }
           }
         }
@@ -636,73 +647,83 @@ export const exportConfigsProgressively = async (
             return;
           }
 
-          if (finalResults.demo?.svg) {
-            configFolder.file('demo.svg', finalResults.demo.svg);
-          }
           configFolder.file('config.yaml', configRecord.config);
 
-          if (finalResults.outlines) {
-            let outlinesFolder: JSZip | null = null;
-            for (const [name, outline] of Object.entries(
-              finalResults.outlines
-            )) {
-              if (debug || !name.startsWith('_')) {
-                if (outline.dxf || outline.svg) {
-                  if (!outlinesFolder) {
-                    outlinesFolder = configFolder.folder('outlines');
+          const outputsFolder = configFolder.folder('outputs');
+
+          if (outputsFolder) {
+            if (finalResults.demo?.svg) {
+              outputsFolder.file('demo.svg', finalResults.demo.svg);
+            }
+
+            if (finalResults.outlines) {
+              let outlinesFolder: JSZip | null = null;
+              for (const [name, outline] of Object.entries(
+                finalResults.outlines
+              )) {
+                if (debug || !name.startsWith('_')) {
+                  if (outline.dxf || outline.svg) {
+                    if (!outlinesFolder) {
+                      outlinesFolder = outputsFolder.folder('outlines');
+                    }
+                    if (outlinesFolder) {
+                      if (outline.dxf)
+                        outlinesFolder.file(`${name}.dxf`, outline.dxf);
+                      if (outline.svg)
+                        outlinesFolder.file(`${name}.svg`, outline.svg);
+                    }
                   }
-                  if (outlinesFolder) {
-                    if (outline.dxf)
-                      outlinesFolder.file(`${name}.dxf`, outline.dxf);
-                    if (outline.svg)
-                      outlinesFolder.file(`${name}.svg`, outline.svg);
+                }
+              }
+            }
+
+            if (
+              finalResults.pcbs &&
+              Object.keys(finalResults.pcbs).length > 0
+            ) {
+              const pcbsFolder = outputsFolder.folder('pcbs');
+              if (pcbsFolder) {
+                for (const [name, pcb] of Object.entries(finalResults.pcbs)) {
+                  const fileName = name.endsWith('.kicad_pcb')
+                    ? name
+                    : `${name}.kicad_pcb`;
+                  pcbsFolder.file(fileName, pcb);
+                }
+              }
+            }
+
+            if (finalResults.cases) {
+              let casesFolder: JSZip | null = null;
+              for (const [name, caseData] of Object.entries(
+                finalResults.cases
+              )) {
+                const hasJscad = !!caseData.jscad;
+                const hasStl = !!caseData.stl;
+                if (hasJscad || hasStl) {
+                  if (!casesFolder) {
+                    casesFolder = outputsFolder.folder('cases');
+                  }
+                  if (casesFolder) {
+                    if (caseData.jscad)
+                      casesFolder.file(`${name}.jscad`, caseData.jscad);
+                    if (caseData.stl)
+                      casesFolder.file(`${name}.stl`, caseData.stl);
                   }
                 }
               }
             }
-          }
 
-          if (finalResults.pcbs && Object.keys(finalResults.pcbs).length > 0) {
-            const pcbsFolder = configFolder.folder('pcbs');
-            if (pcbsFolder) {
-              for (const [name, pcb] of Object.entries(finalResults.pcbs)) {
-                const fileName = name.endsWith('.kicad_pcb')
-                  ? name
-                  : `${name}.kicad_pcb`;
-                pcbsFolder.file(fileName, pcb);
-              }
-            }
-          }
-
-          if (finalResults.cases) {
-            let casesFolder: JSZip | null = null;
-            for (const [name, caseData] of Object.entries(finalResults.cases)) {
-              const hasJscad = !!caseData.jscad;
-              const hasStl = !!caseData.stl;
-              if (hasJscad || hasStl) {
-                if (!casesFolder) {
-                  casesFolder = configFolder.folder('cases');
-                }
-                if (casesFolder) {
-                  if (caseData.jscad)
-                    casesFolder.file(`${name}.jscad`, caseData.jscad);
-                  if (caseData.stl)
-                    casesFolder.file(`${name}.stl`, caseData.stl);
-                }
-              }
-            }
-          }
-
-          if (debug) {
-            const debugFolder = configFolder.folder('debug');
-            if (debugFolder) {
-              debugFolder.file('raw.txt', configRecord.config);
-              for (const [key, value] of Object.entries(finalResults)) {
-                if (['canonical', 'points', 'units'].includes(key)) {
-                  debugFolder.file(
-                    `${key}.yaml`,
-                    JSON.stringify(value, null, 2)
-                  );
+            if (debug) {
+              const debugFolder = outputsFolder.folder('debug');
+              if (debugFolder) {
+                debugFolder.file('raw.txt', configRecord.config);
+                for (const [key, value] of Object.entries(finalResults)) {
+                  if (['canonical', 'points', 'units'].includes(key)) {
+                    debugFolder.file(
+                      `${key}.yaml`,
+                      JSON.stringify(value, null, 2)
+                    );
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Description
This Pull Request consolidates and completes all implementation tasks of **Wave 3** (Archive & File Loading Pipelines and Welcome Feedback) alongside version bumps and changelog updates.

## Technical Details

### 🌊 1. Unified Ergogen Bundle Loader [TASK-012]
- **Changes:**
  - Created a central library [ergogenBundleLoader.ts](file:///Users/mmassarelli/Documents/GitHub/ergogen-gui/src/utils/ergogenBundleLoader.ts) containing types, file size validation, zip structure check, ZIP parser, and list projection functions.
  - Refactored [localFiles.ts](file:///Users/mmassarelli/Documents/GitHub/ergogen-gui/src/utils/localFiles.ts) to delegate file parsing, ZIP extraction, and size limit checks to the central bundle loader.
  - Refactored [github.ts](file:///Users/mmassarelli/Documents/GitHub/ergogen-gui/src/utils/github.ts) to enforce identical file size rules when fetching configuration URLs or repository branches.
  - Refactored [useConfigLoader.ts](file:///Users/mmassarelli/Documents/GitHub/ergogen-gui/src/hooks/useConfigLoader.ts) and [Welcome.tsx](file:///Users/mmassarelli/Documents/GitHub/ergogen-gui/src/pages/Welcome.tsx) to map footprint/outline/template arrays to the context format via the unified `mapSeparateToInjectionsArray` helper.

### 🌊 2. File Size Limits & Corrupted ZIPs Error Handling [TASK-011]
- **Changes:**
  - Implemented `enforceFileSizeLimit` verifying files stay below **50MB for archives** and **10MB for text configurations** (applicable to both local reads and remote fetches).
  - Configured descriptive error handling inside `parseZipArchive` for corrupted archives and case-insensitive check for `config.yaml` or `config.yml` (e.g. `'The file appears to be corrupted.'` or `'The archive is missing a config.yaml file.'`).

### 🌊 3. Interactive Welcome Loading UI [TASK-010]
- **Changes:**
  - Blocked drag-and-drop operations and disabled input fields/buttons on [Welcome.tsx](file:///Users/mmassarelli/Documents/GitHub/ergogen-gui/src/pages/Welcome.tsx) during active loading states to prevent concurrent loads.
  - Added a visual `<Spinner />` animation inside buttons while processing local files or fetching GitHub configurations.
  - Added a global `info` banner state in [ConfigContext.tsx](file:///Users/mmassarelli/Documents/GitHub/ergogen-gui/src/context/ConfigContext.tsx) and updated [Banners.tsx](file:///Users/mmassarelli/Documents/GitHub/ergogen-gui/src/organisms/Banners.tsx) to render blue info messages. Shows count summaries upon loading configurations (e.g. `'Config loaded. Found 3 footprints, 1 outline, and 2 templates.'`).

### 🌊 4. Nested ZIP Outputs [TASK-033]
- **Changes:**
  - Restructured the ZIP exporter in `zip.ts` to place all generated compilation outputs (`demo.svg`, `outlines/`, `pcbs/`, `cases/`, `debug/`) inside an `outputs/` folder at the root of the ZIP.
  - This completely avoids naming collisions with root injection folders (like input `outlines/`).

---

## Verification Results

### Automated Verification
1. **Pre-commit Checklist:**
   - Ran `yarn precommit` which checked formatting, lints, knip graph analysis, and executed unit tests.
   - All linters, formatters, and unused exports rules are completely green with **0 errors**.
2. **Unit Tests:**
   - All **366 unit tests** passed successfully:
     ```bash
     yarn test:unit
     # Tests:       366 passed, 366 total
     # Time:        2.273 s
     ```

---

Closes #168
Closes #167
Closes #166
Closes #194